### PR TITLE
Tiered kv cache implementation along with vattention (mad-lab-cache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,28 @@ a.out.*
 .gitnexus
 .claude/
 .agent.md
+
+# cmake root-level build artifacts
+/CMakeFiles/
+/CMakeCache.txt
+/CTestTestfile.cmake
+/DartConfiguration.tcl
+/cmake_install.cmake
+/bin/
+/CPackConfig.cmake
+/CPackSourceConfig.cmake
+*.so
+*.so.*
+
+# nested cmake build artifacts
+**/CMakeFiles/
+**/cmake_install.cmake
+**/CTestTestfile.cmake
+**/Makefile
+compile_commands.json
+error.txt
+license.cpp
+llama.pc
+ggml/ggml-config.cmake
+ggml/ggml-version.cmake
+tests/libgguf-model-data.a

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ llama.pc
 ggml/ggml-config.cmake
 ggml/ggml-version.cmake
 tests/libgguf-model-data.a
+*.a
+tests/cmake_install.cmake

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ ggml/ggml-version.cmake
 tests/libgguf-model-data.a
 *.a
 tests/cmake_install.cmake
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -144,7 +144,7 @@ poetry.toml
 /*.code-workspace
 /.windsurf/
 # emscripten
-a.out.*
+a.out.*x
 .gitnexus
 .claude/
 .agent.md

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -31,6 +31,7 @@
 #include <list>
 #include <regex>
 #include <set>
+#include <sstream>
 #include <string>
 #include <thread> // for hardware_concurrency
 #include <vector>
@@ -1310,6 +1311,53 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.cache_ram_mib = value;
         }
     ).set_env("LLAMA_ARG_CACHE_RAM").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
+    add_opt(common_arg(
+        {"--kv-tiered"}, "VRAM%,RAM%,SSD%",
+        "enable tiered KV cache with percentages for VRAM, RAM, SSD (e.g., 25,25,50 for 25% VRAM, 25% RAM, 50% SSD)",
+        [](common_params & params, const std::string & value) {
+            params.kv_tiered_enabled = true;
+            // Parse the percentage string
+            std::vector<std::string> parts;
+            std::stringstream ss(value);
+            std::string part;
+            while (std::getline(ss, part, ',')) {
+                parts.push_back(part);
+            }
+            if (parts.size() == 3) {
+                params.kv_tier_hot_pct = std::stof(parts[0]);
+                params.kv_tier_warm_pct = std::stof(parts[1]);
+                params.kv_tier_cold_pct = std::stof(parts[2]);
+            }
+        }
+    ).set_env("LLAMA_ARG_KT_TIERED").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--tier-ssd-path"}, "PATH",
+        "directory for cold tier (SSD) storage",
+        [](common_params & params, const std::string & value) {
+            params.kv_tier_ssd_path = value;
+        }
+    ).set_env("LLAMA_ARG_TIER_SSD_PATH").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--tier-eviction-policy"}, "POLICY",
+        "eviction policy: 0=LRU, 1=LFU, 2=attention, 3=hybrid (default)",
+        [](common_params & params, int value) {
+            params.kv_tier_eviction_policy = value;
+        }
+    ).set_env("LLAMA_ARG_TIER_EVICTION_POLICY").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--tier-compression"}, "TYPE",
+        "compression type: 0=none, 1=int4, 2=int8, 3=lz4, 4=quantized",
+        [](common_params & params, int value) {
+            params.kv_tier_compression = value;
+        }
+    ).set_env("LLAMA_ARG_TIER_COMPRESSION").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--tier-attention-threshold"}, "THRESH",
+        "attention threshold for eviction (0.0-1.0, default: 0.1)",
+        [](common_params & params, int value) {
+            params.kv_tier_attention_threshold = float(value) / 100.0f;
+        }
+    ).set_env("LLAMA_ARG_TIER_ATTENTION_THRESHOLD").set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
         {"-kvu", "--kv-unified"},
         {"-no-kvu", "--no-kv-unified"},

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2431,9 +2431,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_N_GPU_LAYERS"));
     add_opt(common_arg(
-        {"--weight-paging"}, "",
+        {"--weight-paging"},
         "enable NVMe→VRAM demand paging for model weights (allows models larger than VRAM)",
-        [](common_params & params, const std::string & value) {
+        [](common_params & params) {
             params.weight_paging_enabled = true;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_WEIGHT_PAGING"));
@@ -2445,9 +2445,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_WEIGHT_PAGING_SLOTS"));
     add_opt(common_arg(
-        {"--weight-paging-prefetch"}, "",
+        {"--weight-paging-prefetch"},
         "enable async prefetch of next layer (default: enabled)",
-        [](common_params & params, const std::string & value) {
+        [](common_params & params) {
             params.weight_paging_prefetch = true;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_WEIGHT_PAGING_PREFETCH"));

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1359,6 +1359,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_TIER_ATTENTION_THRESHOLD").set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--kv-warm-device"}, "DEVICE",
+        "HIP device index to use as warm KV cache tier (e.g. 1 for 6900XT eGPU); requires --kv-tiered",
+        [](common_params & params, int value) {
+            params.kv_warm_device = value;
+        }
+    ).set_env("LLAMA_ARG_KV_WARM_DEVICE").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"-kvu", "--kv-unified"},
         {"-no-kvu", "--no-kv-unified"},
         "use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)",

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2431,6 +2431,27 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_N_GPU_LAYERS"));
     add_opt(common_arg(
+        {"--weight-paging"}, "",
+        "enable NVMe→VRAM demand paging for model weights (allows models larger than VRAM)",
+        [](common_params & params, const std::string & value) {
+            params.weight_paging_enabled = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_WEIGHT_PAGING"));
+    add_opt(common_arg(
+        {"--weight-paging-slots"}, "N",
+        "number of VRAM slots for weight paging (-1 = auto, default: -1)",
+        [](common_params & params, const std::string & value) {
+            params.weight_paging_slots = std::stoi(value);
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_WEIGHT_PAGING_SLOTS"));
+    add_opt(common_arg(
+        {"--weight-paging-prefetch"}, "",
+        "enable async prefetch of next layer (default: enabled)",
+        [](common_params & params, const std::string & value) {
+            params.weight_paging_prefetch = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_WEIGHT_PAGING_PREFETCH"));
+    add_opt(common_arg(
         {"-sm", "--split-mode"}, "{none,layer,row,tensor}",
         "how to split the model across multiple GPUs, one of:\n"
         "- none: use one GPU only\n"

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1366,6 +1366,27 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_KV_WARM_DEVICE").set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--kv-semantic-index"}, "PATH",
+        "path to embedding model (GGUF) for semantic KV cache indexing (e.g. bge-small); empty = disabled",
+        [](common_params & params, const std::string & value) {
+            params.kv_semantic_index = value;
+        }
+    ).set_env("LLAMA_ARG_KV_SEMANTIC_INDEX").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--kv-semantic-threshold"}, "THRESHOLD",
+        "minimum cosine similarity threshold for semantic prefetch hints (default: 0.65)",
+        [](common_params & params, const std::string & value) {
+            params.kv_semantic_threshold = std::stof(value);
+        }
+    ).set_env("LLAMA_ARG_KV_SEMANTIC_THRESHOLD").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--kv-semantic-topk"}, "K",
+        "number of prefetch hints to return (default: 5)",
+        [](common_params & params, int value) {
+            params.kv_semantic_top_k = value;
+        }
+    ).set_env("LLAMA_ARG_KV_SEMANTIC_TOPK").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"-kvu", "--kv-unified"},
         {"-no-kvu", "--no-kv-unified"},
         "use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)",

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1343,7 +1343,7 @@ common_init_result_ptr common_init_from_params(common_params & params) {
         common_set_adapter_lora(lctx, params.lora_adapters);
     }
 
-    if (params.warmup) {
+    if (params.warmup && !params.weight_paging_enabled) {
         LOG_WRN("%s: warming up the model with an empty run - please wait ... (--no-warmup to disable)\n", __func__);
 
         llama_set_warmup(lctx, true);
@@ -1487,6 +1487,11 @@ struct llama_model_params common_model_params_to_llama(common_params & params) {
     mparams.progress_callback           = params.load_progress_callback;
     mparams.progress_callback_user_data = params.load_progress_callback_user_data;
     mparams.no_alloc                    = params.no_alloc;
+
+    // Weight paging parameters
+    mparams.weight_paging_enabled  = params.weight_paging_enabled;
+    mparams.weight_paging_slots    = params.weight_paging_slots;
+    mparams.weight_paging_prefetch = params.weight_paging_prefetch;
 
     return mparams;
 }

--- a/common/common.h
+++ b/common/common.h
@@ -536,7 +536,7 @@ struct common_params {
     // weight paging parameters
     bool    weight_paging_enabled = false;  // enable NVMe→VRAM demand paging for model weights
     int32_t weight_paging_slots   = -1;     // number of VRAM slots for weight paging (-1 = auto)
-    bool    weight_paging_prefetch = true;  // enable async prefetch of next layer
+    bool    weight_paging_prefetch = false;  // enable async prefetch of next layer
 
     bool single_turn       = false; // single turn chat conversation
 

--- a/common/common.h
+++ b/common/common.h
@@ -573,6 +573,16 @@ struct common_params {
     int32_t checkpoint_every_nt = 8192;  // make a checkpoint every n tokens during prefill
     int32_t cache_ram_mib       = 8192;  // -1 = no limit, 0 - disable, 1 = 1 MiB, etc.
 
+    // tiered KV cache parameters
+    bool kv_tiered_enabled    = false;   // enable tiered KV cache
+    float kv_tier_hot_pct     = 25.0f;   // hot tier percentage (VRAM)
+    float kv_tier_warm_pct    = 25.0f;   // warm tier percentage (RAM)
+    float kv_tier_cold_pct    = 50.0f;   // cold tier percentage (SSD)
+    std::string kv_tier_ssd_path = "";   // SSD path for cold tier storage
+    int kv_tier_eviction_policy = 3;     // 0=LRU, 1=LFU, 2=attention, 3=hybrid (default)
+    int kv_tier_compression   = 1;       // 0=none, 1=int4, 2=int8, 3=lz4, 4=quantized
+    float kv_tier_attention_threshold = 0.1f;  // attention threshold for eviction
+
     std::string hostname      = "127.0.0.1";
     std::string public_path   = "";                                                                         // NOLINT
     std::string api_prefix    = "";                                                                         // NOLINT

--- a/common/common.h
+++ b/common/common.h
@@ -582,6 +582,7 @@ struct common_params {
     int kv_tier_eviction_policy = 3;     // 0=LRU, 1=LFU, 2=attention, 3=hybrid (default)
     int kv_tier_compression   = 1;       // 0=none, 1=int4, 2=int8, 3=lz4, 4=quantized
     float kv_tier_attention_threshold = 0.1f;  // attention threshold for eviction
+    int   kv_warm_device        = -1;    // HIP device index for warm KV tier (-1 = disabled)
 
     std::string hostname      = "127.0.0.1";
     std::string public_path   = "";                                                                         // NOLINT

--- a/common/common.h
+++ b/common/common.h
@@ -583,6 +583,7 @@ struct common_params {
     int kv_tier_compression   = 1;       // 0=none, 1=int4, 2=int8, 3=lz4, 4=quantized
     float kv_tier_attention_threshold = 0.1f;  // attention threshold for eviction
     int   kv_warm_device        = -1;    // HIP device index for warm KV tier (-1 = disabled)
+    int   kv_tier_total_ctx     = 0;     // full ctx budget across all tiers (set at load time)
 
     std::string hostname      = "127.0.0.1";
     std::string public_path   = "";                                                                         // NOLINT

--- a/common/common.h
+++ b/common/common.h
@@ -584,6 +584,9 @@ struct common_params {
     float kv_tier_attention_threshold = 0.1f;  // attention threshold for eviction
     int   kv_warm_device        = -1;    // HIP device index for warm KV tier (-1 = disabled)
     int   kv_tier_total_ctx     = 0;     // full ctx budget across all tiers (set at load time)
+    std::string kv_semantic_index = "";   // path to embedding model for semantic KV index (empty = disabled)
+    float kv_semantic_threshold = 0.65f;  // minimum cosine similarity threshold for prefetch hints
+    int   kv_semantic_top_k     = 5;      // number of prefetch hints to return
 
     std::string hostname      = "127.0.0.1";
     std::string public_path   = "";                                                                         // NOLINT

--- a/common/common.h
+++ b/common/common.h
@@ -533,6 +533,11 @@ struct common_params {
     bool no_extra_bufts    = false; // disable extra buffer types (used for weight repacking)
     bool no_host           = false; // bypass host buffer allowing extra buffers to be used
 
+    // weight paging parameters
+    bool    weight_paging_enabled = false;  // enable NVMe→VRAM demand paging for model weights
+    int32_t weight_paging_slots   = -1;     // number of VRAM slots for weight paging (-1 = auto)
+    bool    weight_paging_prefetch = true;  // enable async prefetch of next layer
+
     bool single_turn       = false; // single turn chat conversation
 
     ggml_type cache_type_k = GGML_TYPE_F16; // KV cache data type for the K

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -53,9 +53,10 @@ static std::vector<llama_device_memory_data> common_get_device_memory_data(
     }, &ud);
 
     llama_model_params mparams_copy = *mparams;
-    mparams_copy.no_alloc  = true;
-    mparams_copy.use_mmap  = false;
-    mparams_copy.use_mlock = false;
+    mparams_copy.no_alloc       = true;
+    mparams_copy.use_mmap       = false;
+    mparams_copy.use_mlock      = false;
+    mparams_copy.use_direct_io  = false;
 
     llama_model * model = llama_model_load_from_file(path_model, mparams_copy);
     if (model == nullptr) {

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -12,7 +12,7 @@
 #include <cfloat>
 #include <cmath>
 
-extern "C" GGML_API int turbo3_cpu_wht_group_size;
+extern "C" int turbo3_cpu_wht_group_size;
 
 // ggml_compute_forward_dup
 

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1193,7 +1193,7 @@ struct ggml_cuda_graph {
     std::vector<node_properties> node_props;
 
     bool is_enabled() const {
-        static const bool disable_cuda_graphs_due_to_env = (getenv("GGML_CUDA_DISABLE_GRAPHS") != nullptr);
+        const bool disable_cuda_graphs_due_to_env = (getenv("GGML_CUDA_DISABLE_GRAPHS") != nullptr);
         return !(disable_due_to_gpu_arch || disable_cuda_graphs_due_to_env);
     }
 #endif

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1426,6 +1426,54 @@ static cudaError_t ggml_cuda_cpy_tensor_2d(
     const int64_t i1_diff = i1_high - i1_low;
 
     const char * x = src_ptr + i1_low*nb1 + i2*nb2 + i3*nb3;
+
+#if defined(GGML_USE_HIP)
+    // hipMemcpy2DAsync with hipMemcpyDeviceToDevice requires P2P access between devices.
+    // For mixed-architecture multi-GPU setups (e.g. gfx1201 + gfx1030) without P2P,
+    // it fails asynchronously with hipErrorNoBinaryForGpu when the internal copy kernel
+    // isn't compiled for the destination device. Detect cross-device copies via pointer
+    // attributes and fall back to row-wise hipMemcpyPeerAsync, which stages through the
+    // host when P2P is unavailable. Mirrors the fix in ggml_cuda_Memcpy2DPeerAsync.
+    hipPointerAttribute_t src_attr = {};
+    hipPointerAttribute_t dst_attr = {};
+    const bool src_ok = hipPointerGetAttributes(&src_attr, x)       == hipSuccess;
+    const bool dst_ok = hipPointerGetAttributes(&dst_attr, dst_ptr) == hipSuccess;
+    if (src_ok && dst_ok && src_attr.device != dst_attr.device) {
+        const int src_dev = src_attr.device;
+        const int dst_dev = dst_attr.device;
+        if (nb0 == ts && nb1 == ts*ne0/bs) {
+            return hipMemcpyPeerAsync(dst_ptr, dst_dev, x, src_dev, i1_diff*nb1, stream);
+        } else if (nb0 == ts) {
+            const size_t row_bytes = ts*ne0/bs;
+            for (int64_t i1 = 0; i1 < i1_diff; i1++) {
+                hipError_t err = hipMemcpyPeerAsync(
+                    dst_ptr + i1*row_bytes, dst_dev,
+                    x + i1*nb1,             src_dev,
+                    row_bytes, stream);
+                if (err != hipSuccess) {
+                    return err;
+                }
+            }
+            return hipSuccess;
+        } else {
+            for (int64_t i1 = 0; i1 < i1_diff; i1++) {
+                const char * rx = x + i1*nb1;
+                char       * rd = dst_ptr + i1*ts*ne0/bs;
+                for (int64_t e = 0; e < ne0; e++) {
+                    hipError_t err = hipMemcpyPeerAsync(
+                        rd + e*(ts/bs), dst_dev,
+                        rx + e*nb0,     src_dev,
+                        ts/bs, stream);
+                    if (err != hipSuccess) {
+                        return err;
+                    }
+                }
+            }
+            return hipSuccess;
+        }
+    }
+#endif
+
     if (nb0 == ts && nb1 == ts*ne0/bs) {
         return cudaMemcpyAsync(dst_ptr, x, i1_diff*nb1, cudaMemcpyDeviceToDevice, stream);
     } else if (nb0 == ts) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -321,6 +321,11 @@ extern "C" {
         bool use_extra_bufts; // use extra buffer types (used for weight repacking)
         bool no_host;         // bypass host buffer allowing extra buffers to be used
         bool no_alloc;        // only load metadata and simulate memory allocations
+
+        // Weight paging parameters (NVMe→VRAM demand paging)
+        bool weight_paging_enabled;    // enable NVMe→VRAM demand paging for model weights
+        int32_t weight_paging_slots;   // number of VRAM slots for weight paging (-1 = auto)
+        bool weight_paging_prefetch;   // enable async prefetch of next layer
     };
 
     struct llama_sampler_seq_config {

--- a/plans/errors/command.md
+++ b/plans/errors/command.md
@@ -1,0 +1,28 @@
+Here is what I use to start the server:
+
+llama-server-feature \
+          --model ~/models/MiniMax-M2.7-UD-IQ3_S-00001-of-00003.gguf \
+          -ngl 999 \
+          --device ROCm0 \
+          --ctx-size 196608 \
+          --cache-type-k turbo4 \
+          --cache-type-v turbo4 \
+          --flash-attn on \
+          --metrics \
+          --port 8080 \
+          --host 0.0.0.0 \
+          --no-mmap \
+          --kv-tiered 12.5,50,37.5 \
+          --tier-ssd-path ~/kv-cold \
+          --tier-eviction-policy 3 \
+          --parallel 1 \
+          --kv-semantic-index ~/models/bge-small-en-v1.5-q8_0.gguf \
+          --kv-semantic-threshold 0.65 \
+          --kv-semantic-topk 5 \
+          --alias default \
+          --direct-io \
+          --kv-warm-device 1 \
+          --weight-paging \
+          --fit off \
+          --weight-paging-slots 8 \
+          --jinja

--- a/plans/errors/output.md
+++ b/plans/errors/output.md
@@ -1,0 +1,332 @@
+ulimit: Permission denied when changing resource of type 'Maximum size that may be locked into memory'
+ggml_cuda_init: found 2 ROCm devices (Total VRAM: 48992 MiB):
+  Device 0: AMD Radeon AI PRO R9700, gfx1201 (0x1201), VMM: no, Wave Size: 32, VRAM: 32624 MiB
+  Device 1: AMD Radeon RX 6900 XT, gfx1030 (0x1030), VMM: no, Wave Size: 32, VRAM: 16368 MiB
+build_info: b8942-ff060471c
+system_info: n_threads = 12 (n_threads_batch = 12) / 24 | ROCm : NO_VMM = 1 | PEER_MAX_BATCH_SIZE = 128 | FA_ALL_QUANTS = 1 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 | 
+Running without SSL
+init: using 23 threads for HTTP server
+start: binding port with default address family
+main: loading model
+srv    load_model: loading model '/home/kmbandy/models/MiniMax-M2.7-UD-IQ3_S-00001-of-00003.gguf'
+srv    load_model: tiered KV: total ctx=196608, hot ctx=24576 (12%)
+llama_model_load_from_file_impl: using device ROCm0 (AMD Radeon AI PRO R9700) (0000:42:00.0) - 32532 MiB free
+llama_model_loader: additional 2 GGUFs metadata loaded.
+llama_model_loader: loaded meta data with 50 key-value pairs and 809 tensors from /home/kmbandy/models/MiniMax-M2.7-UD-IQ3_S-00001-of-00003.gguf (version GGUF V3 (latest))
+llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+llama_model_loader: - kv   0:                       general.architecture str              = minimax-m2
+llama_model_loader: - kv   1:                               general.type str              = model
+llama_model_loader: - kv   2:                     general.sampling.top_k i32              = 40
+llama_model_loader: - kv   3:                     general.sampling.top_p f32              = 0.950000
+llama_model_loader: - kv   4:                      general.sampling.temp f32              = 1.000000
+llama_model_loader: - kv   5:                               general.name str              = Minimax-M2.7
+llama_model_loader: - kv   6:                           general.basename str              = Minimax-M2.7
+llama_model_loader: - kv   7:                       general.quantized_by str              = Unsloth
+llama_model_loader: - kv   8:                         general.size_label str              = 256x4.9B
+llama_model_loader: - kv   9:                            general.license str              = other
+llama_model_loader: - kv  10:                       general.license.name str              = modified-mit
+llama_model_loader: - kv  11:                       general.license.link str              = https://github.com/MiniMax-AI/MiniMax...
+llama_model_loader: - kv  12:                           general.repo_url str              = https://huggingface.co/unsloth
+llama_model_loader: - kv  13:                               general.tags arr[str,1]       = ["text-generation"]
+llama_model_loader: - kv  14:                     minimax-m2.block_count u32              = 62
+llama_model_loader: - kv  15:                  minimax-m2.context_length u32              = 196608
+llama_model_loader: - kv  16:                minimax-m2.embedding_length u32              = 3072
+llama_model_loader: - kv  17:             minimax-m2.feed_forward_length u32              = 1536
+llama_model_loader: - kv  18:            minimax-m2.attention.head_count u32              = 48
+llama_model_loader: - kv  19:         minimax-m2.attention.head_count_kv u32              = 8
+llama_model_loader: - kv  20:                  minimax-m2.rope.freq_base f32              = 5000000.000000
+llama_model_loader: - kv  21: minimax-m2.attention.layer_norm_rms_epsilon f32              = 0.000001
+llama_model_loader: - kv  22:                    minimax-m2.expert_count u32              = 256
+llama_model_loader: - kv  23:               minimax-m2.expert_used_count u32              = 8
+llama_model_loader: - kv  24:              minimax-m2.expert_gating_func u32              = 2
+llama_model_loader: - kv  25:            minimax-m2.attention.key_length u32              = 128
+llama_model_loader: - kv  26:          minimax-m2.attention.value_length u32              = 128
+llama_model_loader: - kv  27:      minimax-m2.expert_feed_forward_length u32              = 1536
+llama_model_loader: - kv  28:            minimax-m2.rope.dimension_count u32              = 64
+llama_model_loader: - kv  29:                       tokenizer.ggml.model str              = gpt2
+llama_model_loader: - kv  30:                         tokenizer.ggml.pre str              = minimax-m2
+llama_model_loader: - kv  31:                      tokenizer.ggml.tokens arr[str,200064]  = ["Ā", "ā", "Ă", "ă", "Ą", "ą", ...
+llama_model_loader: - kv  32:                  tokenizer.ggml.token_type arr[i32,200064]  = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...
+llama_model_loader: - kv  33:                      tokenizer.ggml.merges arr[str,199744]  = ["Ġ Ġ", "Ġ t", "Ġ a", "i n", "e r...
+llama_model_loader: - kv  34:                tokenizer.ggml.bos_token_id u32              = 200034
+llama_model_loader: - kv  35:                tokenizer.ggml.eos_token_id u32              = 200020
+llama_model_loader: - kv  36:            tokenizer.ggml.unknown_token_id u32              = 200021
+llama_model_loader: - kv  37:            tokenizer.ggml.padding_token_id u32              = 200004
+llama_model_loader: - kv  38:               tokenizer.ggml.add_bos_token bool             = false
+llama_model_loader: - kv  39:               tokenizer.ggml.add_sep_token bool             = false
+llama_model_loader: - kv  40:                    tokenizer.chat_template str              = {# ----------‑‑‑ special token ...
+llama_model_loader: - kv  41:               general.quantization_version u32              = 2
+llama_model_loader: - kv  42:                          general.file_type u32              = 26
+llama_model_loader: - kv  43:                      quantize.imatrix.file str              = MiniMax-M2.7-GGUF/imatrix_unsloth.gguf
+llama_model_loader: - kv  44:                   quantize.imatrix.dataset str              = unsloth_calibration_MiniMax-M2.7.txt
+llama_model_loader: - kv  45:             quantize.imatrix.entries_count u32              = 496
+llama_model_loader: - kv  46:              quantize.imatrix.chunks_count u32              = 81
+llama_model_loader: - kv  47:                                   split.no u16              = 0
+llama_model_loader: - kv  48:                        split.tensors.count i32              = 809
+llama_model_loader: - kv  49:                                split.count u16              = 3
+llama_model_loader: - type  f32:  373 tensors
+llama_model_loader: - type q6_K:  250 tensors
+llama_model_loader: - type iq3_s:   62 tensors
+llama_model_loader: - type iq2_s:  124 tensors
+print_info: file format = GGUF V3 (latest)
+print_info: file type   = IQ3_S - 3.4375 bpw
+print_info: file size   = 77.86 GiB (2.92 BPW) 
+load: 0 unused tokens
+load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
+load: printing all EOG tokens:
+load:   - 200004 ('<fim_pad>')
+load:   - 200005 ('<reponame>')
+load:   - 200020 ('[e~[')
+load: special tokens cache size = 54
+load: token to piece cache size = 1.3355 MB
+print_info: arch                  = minimax-m2
+print_info: vocab_only            = 0
+print_info: no_alloc              = 0
+print_info: n_ctx_train           = 196608
+print_info: n_embd                = 3072
+print_info: n_embd_inp            = 3072
+print_info: n_layer               = 62
+print_info: n_head                = 48
+print_info: n_head_kv             = 8
+print_info: n_rot                 = 64
+print_info: n_swa                 = 0
+print_info: is_swa_any            = 0
+print_info: n_embd_head_k         = 128
+print_info: n_embd_head_v         = 128
+print_info: n_gqa                 = 6
+print_info: n_embd_k_gqa          = 1024
+print_info: n_embd_v_gqa          = 1024
+print_info: f_norm_eps            = 0.0e+00
+print_info: f_norm_rms_eps        = 1.0e-06
+print_info: f_clamp_kqv           = 0.0e+00
+print_info: f_max_alibi_bias      = 0.0e+00
+print_info: f_logit_scale         = 0.0e+00
+print_info: f_attn_scale          = 0.0e+00
+print_info: n_ff                  = 1536
+print_info: n_expert              = 256
+print_info: n_expert_used         = 8
+print_info: n_expert_groups       = 0
+print_info: n_group_used          = 0
+print_info: causal attn           = 1
+print_info: pooling type          = -1
+print_info: rope type             = 2
+print_info: rope scaling          = linear
+print_info: freq_base_train       = 5000000.0
+print_info: freq_scale_train      = 1
+print_info: n_ctx_orig_yarn       = 196608
+print_info: rope_yarn_log_mul     = 0.0000
+print_info: rope_finetuned        = unknown
+print_info: model type            = 230B.A10B
+print_info: model params          = 228.69 B
+print_info: general.name          = Minimax-M2.7
+print_info: vocab type            = BPE
+print_info: n_vocab               = 200064
+print_info: n_merges              = 199744
+print_info: BOS token             = 200034 ']~!b['
+print_info: EOS token             = 200020 '[e~['
+print_info: UNK token             = 200021 ']!d~['
+print_info: PAD token             = 200004 '<fim_pad>'
+print_info: LF token              = 10 'Ċ'
+print_info: FIM PRE token         = 200001 '<fim_prefix>'
+print_info: FIM SUF token         = 200003 '<fim_suffix>'
+print_info: FIM MID token         = 200002 '<fim_middle>'
+print_info: FIM PAD token         = 200004 '<fim_pad>'
+print_info: FIM REP token         = 200005 '<reponame>'
+print_info: EOG token             = 200004 '<fim_pad>'
+print_info: EOG token             = 200005 '<reponame>'
+print_info: EOG token             = 200020 '[e~['
+print_info: max token length      = 256
+load_tensors: loading model tensors, this can take a while... (mmap = false, direct_io = true)
+load_tensors: offloading output layer to GPU
+load_tensors: offloading 61 repeating layers to GPU
+load_tensors: offloaded 63/63 layers to GPU
+load_tensors:          CPU model buffer size =     0.00 MiB
+load_tensors:        ROCm0 model buffer size =     0.00 MiB
+init_weight_pager: initializing weight pager with 809 pages
+init_weight_pager: VRAM: 32532 MiB free / 32624 MiB total
+init_weight_pager: initializing VRAM pool with 8 slots (495 MiB each = 3960 MiB total)
+init_weight_pager: calling init_pool with slot_size=519045120 n_slots=8
+init_pool: allocating 8 slots of 519045120 bytes each
+init_pool: allocated pool.base=0x7f056dc00000 (slot_size=519045120, n_slots=8)
+init_weight_pager: init_pool succeeded
+init_weight_pager: set placeholder data pointers on 809 weight tensors
+init_weight_pager: io_uring initialized for async prefetch
+init_weight_pager: weight pager initialized
+common_init_result: added <fim_pad> logit bias = -inf
+common_init_result: added <reponame> logit bias = -inf
+common_init_result: added [e~[ logit bias = -inf
+llama_context: constructing llama_context
+llama_context: n_seq_max     = 1
+llama_context: n_ctx         = 24576
+llama_context: n_ctx_seq     = 24576
+llama_context: n_batch       = 2048
+llama_context: n_ubatch      = 512
+llama_context: causal_attn   = 1
+llama_context: flash_attn    = enabled
+llama_context: kv_unified    = false
+llama_context: freq_base     = 5000000.0
+llama_context: freq_scale    = 1
+llama_context: n_ctx_seq (24576) < n_ctx_train (196608) -- the full capacity of the model will not be utilized
+llama_context:  ROCm_Host  output buffer size =     0.76 MiB
+llama_kv_cache:      ROCm0 KV buffer size =  1581.13 MiB
+llama_kv_cache: TurboQuant rotation matrices initialized (128x128)
+llama_kv_cache: size = 1581.00 MiB ( 24576 cells,  62 layers,  1/1 seqs), K (turbo4):  790.50 MiB, V (turbo4):  790.50 MiB
+llama_kv_cache: upstream attention rotation disabled (TurboQuant uses kernel-level WHT)
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 128
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 128
+sched_reserve: reserving ...
+sched_reserve: resolving fused Gated Delta Net support:
+sched_reserve: fused Gated Delta Net (autoregressive) enabled
+sched_reserve: fused Gated Delta Net (chunked) enabled
+sched_reserve:      ROCm0 compute buffer size =   396.75 MiB
+sched_reserve:  ROCm_Host compute buffer size =    60.01 MiB
+sched_reserve: graph nodes  = 4099
+sched_reserve: graph splits = 2
+sched_reserve: reserve took 22.15 ms, sched copies = 1
+llama_model_load_from_file_impl: using device ROCm0 (AMD Radeon AI PRO R9700) (0000:42:00.0) - 26444 MiB free
+llama_model_load_from_file_impl: using device ROCm1 (AMD Radeon RX 6900 XT) (0000:0b:00.0) - 16332 MiB free
+llama_model_loader: loaded meta data with 29 key-value pairs and 197 tensors from /home/kmbandy/models/bge-small-en-v1.5-q8_0.gguf (version GGUF V3 (latest))
+llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+llama_model_loader: - kv   0:                       general.architecture str              = bert
+llama_model_loader: - kv   1:                               general.type str              = model
+llama_model_loader: - kv   2:                               general.name str              = Bge Small En v1.5
+llama_model_loader: - kv   3:                            general.version str              = v1.5
+llama_model_loader: - kv   4:                           general.finetune str              = en
+llama_model_loader: - kv   5:                           general.basename str              = bge
+llama_model_loader: - kv   6:                         general.size_label str              = small
+llama_model_loader: - kv   7:                            general.license str              = mit
+llama_model_loader: - kv   8:                               general.tags arr[str,5]       = ["sentence-transformers", "feature-ex...
+llama_model_loader: - kv   9:                          general.languages arr[str,1]       = ["en"]
+llama_model_loader: - kv  10:                           bert.block_count u32              = 12
+llama_model_loader: - kv  11:                        bert.context_length u32              = 512
+llama_model_loader: - kv  12:                      bert.embedding_length u32              = 384
+llama_model_loader: - kv  13:                   bert.feed_forward_length u32              = 1536
+llama_model_loader: - kv  14:                  bert.attention.head_count u32              = 12
+llama_model_loader: - kv  15:          bert.attention.layer_norm_epsilon f32              = 0.000000
+llama_model_loader: - kv  16:                      bert.attention.causal bool             = false
+llama_model_loader: - kv  17:                          bert.pooling_type u32              = 2
+llama_model_loader: - kv  18:            tokenizer.ggml.token_type_count u32              = 2
+llama_model_loader: - kv  19:                       tokenizer.ggml.model str              = bert
+llama_model_loader: - kv  20:                         tokenizer.ggml.pre str              = jina-v2-en
+llama_model_loader: - kv  21:                      tokenizer.ggml.tokens arr[str,30522]   = ["[PAD]", "[unused0]", "[unused1]", "...
+llama_model_loader: - kv  22:                  tokenizer.ggml.token_type arr[i32,30522]   = [3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...
+llama_model_loader: - kv  23:            tokenizer.ggml.unknown_token_id u32              = 100
+llama_model_loader: - kv  24:          tokenizer.ggml.seperator_token_id u32              = 102
+llama_model_loader: - kv  25:            tokenizer.ggml.padding_token_id u32              = 0
+llama_model_loader: - kv  26:               tokenizer.ggml.mask_token_id u32              = 103
+llama_model_loader: - kv  27:               general.quantization_version u32              = 2
+llama_model_loader: - kv  28:                          general.file_type u32              = 7
+llama_model_loader: - type  f32:  124 tensors
+llama_model_loader: - type q8_0:   73 tensors
+print_info: file format = GGUF V3 (latest)
+print_info: file type   = Q8_0
+print_info: file size   = 34.38 MiB (8.68 BPW) 
+load: 0 unused tokens
+load: printing all EOG tokens:
+load:   - 0 ('[PAD]')
+load: special tokens cache size = 5
+load: token to piece cache size = 0.2032 MB
+print_info: arch                  = bert
+print_info: vocab_only            = 0
+print_info: no_alloc              = 0
+print_info: n_ctx_train           = 512
+print_info: n_embd                = 384
+print_info: n_embd_inp            = 384
+print_info: n_layer               = 12
+print_info: n_head                = 12
+print_info: n_head_kv             = 12
+print_info: n_rot                 = 32
+print_info: n_swa                 = 0
+print_info: is_swa_any            = 0
+print_info: n_embd_head_k         = 32
+print_info: n_embd_head_v         = 32
+print_info: n_gqa                 = 1
+print_info: n_embd_k_gqa          = 384
+print_info: n_embd_v_gqa          = 384
+print_info: f_norm_eps            = 1.0e-12
+print_info: f_norm_rms_eps        = 0.0e+00
+print_info: f_clamp_kqv           = 0.0e+00
+print_info: f_max_alibi_bias      = 0.0e+00
+print_info: f_logit_scale         = 0.0e+00
+print_info: f_attn_scale          = 0.0e+00
+print_info: n_ff                  = 1536
+print_info: n_expert              = 0
+print_info: n_expert_used         = 0
+print_info: n_expert_groups       = 0
+print_info: n_group_used          = 0
+print_info: causal attn           = 0
+print_info: pooling type          = 2
+print_info: rope type             = 2
+print_info: rope scaling          = linear
+print_info: freq_base_train       = 10000.0
+print_info: freq_scale_train      = 1
+print_info: n_ctx_orig_yarn       = 512
+print_info: rope_yarn_log_mul     = 0.0000
+print_info: rope_finetuned        = unknown
+print_info: model type            = 33M
+print_info: model params          = 33.21 M
+print_info: general.name          = Bge Small En v1.5
+print_info: vocab type            = WPM
+print_info: n_vocab               = 30522
+print_info: n_merges              = 0
+print_info: BOS token             = 101 '[CLS]'
+print_info: UNK token             = 100 '[UNK]'
+print_info: SEP token             = 102 '[SEP]'
+print_info: PAD token             = 0 '[PAD]'
+print_info: MASK token            = 103 '[MASK]'
+print_info: LF token              = 0 '[PAD]'
+print_info: FIM PAD token         = 0 '[PAD]'
+print_info: EOG token             = 0 '[PAD]'
+print_info: max token length      = 21
+load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
+load_tensors: offloading 0 repeating layers to GPU
+load_tensors: offloaded 0/13 layers to GPU
+load_tensors:   CPU_Mapped model buffer size =    34.38 MiB
+................................................
+llama_context: constructing llama_context
+llama_context: n_seq_max     = 1
+llama_context: n_ctx         = 512
+llama_context: n_ctx_seq     = 512
+llama_context: n_batch       = 512
+llama_context: n_ubatch      = 512
+llama_context: causal_attn   = 0
+llama_context: flash_attn    = auto
+llama_context: kv_unified    = false
+llama_context: freq_base     = 10000.0
+llama_context: freq_scale    = 1
+llama_context:        CPU  output buffer size =     0.12 MiB
+sched_reserve: reserving ...
+sched_reserve: Flash Attention was auto, set to enabled
+sched_reserve: resolving fused Gated Delta Net support:
+sched_reserve: fused Gated Delta Net (autoregressive) enabled
+sched_reserve: fused Gated Delta Net (chunked) enabled
+sched_reserve:      ROCm0 compute buffer size =     5.10 MiB
+sched_reserve:  ROCm_Host compute buffer size =     3.76 MiB
+sched_reserve: graph nodes  = 396
+sched_reserve: graph splits = 208 (with bs=512), 1 (with bs=1)
+sched_reserve: reserve took 27.62 ms, sched copies = 1
+srv  server_tiere: semantic KV index loaded: /home/kmbandy/models/bge-small-en-v1.5-q8_0.gguf (CPU)
+srv    load_model: tiered cache initialized, hot=12.500000%, warm=50.000000%, cold=37.500000%
+srv    load_model: initializing slots, n_slots = 1
+process_ubatch: calling ggml_backend_sched_alloc_graph
+process_ubatch: ggml_backend_sched_alloc_graph succeeded
+graph_compute: calling ggml_backend_sched_graph_compute_async
+weight_pager_eval_cb: tensor=embd ask=false
+weight_pager_eval_cb: pager=0x55f6a0b35a80 pool.base=0x7f056dc00000 pool.n_slots=8
+ensure: tensor=token_embd.weight page_idx=0 slot_idx=-1 vram_ptr=(nil)
+ensure: calling page_in for tensor token_embd.weight
+page_in: loading tensor token_embd.weight (file_idx=1, offset=504203680, size=504161280)
+page_in: pread fd=13 dst=0x7f056dc00000 size=504161280 offset=504203680
+page_in: pread returned 504161280 (errno=21)
+ensure: page_in returned, page.slot_idx=0 page.vram_ptr=0x7f056dc00000
+weight_pager_eval_cb: tensor=norm-0 ask=false
+weight_pager_eval_cb: pager=0x55f6a0b35a80 pool.base=0x7f056dc00000 pool.n_slots=8
+weight_pager_eval_cb: tensor=attn_norm-0 ask=false
+weight_pager_eval_cb: pager=0x55f6a0b35a80 pool.base=0x7f056dc00000 pool.n_slots=8
+ensure: tensor=blk.0.attn_norm.weight page_idx=7 slot_idx=-1 vram_ptr=(nil)
+ensure: calling page_in for tensor blk.0.attn_norm.weight
+page_in: loading tensor blk.0.attn_norm.weight (file_idx=1, offset=1010949536, size=12288)
+page_in: pread fd=13 dst=0x7f05aba00000 size=12288 offset=1010949536
+page_in: pread returned 12288 (errno=21)
+ensure: page_in returned, page.slot_idx=2 page.vram_ptr=0x7f05aba00000
+fish: Job 1, '/home/kmbandy/GitHub/llama.cpp/…' terminated by signal SIGSEGV (Address boundary error)

--- a/plans/kv-embed-model.md
+++ b/plans/kv-embed-model.md
@@ -1,0 +1,148 @@
+  ---                                                                                                                                        
+  Phase 1 — Embed model infrastructure
+                                                                                                                                             
+  You are implementing a semantic KV cache index for llama-server on a ROCm/HIP build.
+  SSH target: ssh kmbandy@mad-lab-main                                                                                                       
+  Repo: ~/GitHub/llama.cpp, branch: feature-kv-cache-improvements                                                                            
+  Build: cd ~/GitHub/llama.cpp && cmake --build build --target llama-server -j$(nproc)                                                       
+                                                                                                                                             
+  Goal: Add optional bge-small embedding model support to server_tiered_cache.                                                               
+                  
+  1. Add --kv-semantic-index <path> to common_params (follow how --model is added in                                                         
+     src/common/common.h and common.cpp). Default empty string = disabled.
+                                                                                                                                             
+  2. In tools/server/server-tiered-cache.h, add an optional embed model context:                                                             
+     - struct llama_model * sem_model = nullptr;                                                                                             
+     - struct llama_context * sem_ctx = nullptr;                                                                                             
+     - std::vector<float> embed(const std::string & text);
+     - bool sem_enabled() const { return sem_model != nullptr; }                                                                             
+                  
+  3. In server_tiered_cache constructor, if params.kv_semantic_index is non-empty:                                                           
+     - Load the model with llama_model_load() using n_gpu_layers=0 (CPU always)
+     - Create context with n_ctx=512, embeddings=true                                                                                        
+     - Log: "semantic KV index loaded: <path> (CPU)"                                                                                         
+                                                                                                                                             
+  4. Implement embed(): tokenize text, run llama_decode(), extract embeddings via                                                            
+     llama_get_embeddings_seq(), L2-normalize the result vector, return it.                                                                  
+                                                                                                                                             
+  5. Add destructor cleanup for sem_model/sem_ctx.
+                                                                                                                                             
+  Build must pass clean. No functional behavior change yet — just the infrastructure.                                                        
+  
+  ---                                                                                                                                        
+  Phase 2 — Fingerprint on eviction
+
+  Continuing feature-kv-cache-improvements on mad-lab-main (ssh kmbandy@mad-lab-main).
+  Repo: ~/GitHub/llama.cpp. Build: cmake --build build --target llama-server -j$(nproc)                                                      
+                                                                                                                                             
+  Phase 1 is complete: server_tiered_cache has sem_model/sem_ctx and an embed() method.                                                      
+                                                                                                                                             
+  Goal: When tokens evict to warm or cold, compute and store a semantic fingerprint.                                                         
+                  
+  1. Add to llama-kv-cache-tiered.h:                                                                                                         
+     struct SemanticFingerprint {
+         std::vector<llama_pos> positions;  // token positions this covers                                                                   
+         std::vector<float>     embedding;  // 768-dim normalized vector                                                                     
+         llama_cache_tier       tier;       // TIER_WARM or TIER_COLD
+         uint64_t               turn;       // conversation turn when evicted                                                                
+     };                                                                                                                                      
+     Add: std::vector<SemanticFingerprint> fingerprints; to llama_kv_cache_tiered private.                                                   
+     Add: void add_fingerprint(const std::vector<llama_pos>& positions,                                                                      
+                                std::vector<float>&& embedding, llama_cache_tier tier);
+                                                                                                                                             
+  2. In server_tiered_cache::evict_from_slot(), after successful eviction:                                                                   
+     - If sem_enabled(), detokenize the evicted positions using llama_token_to_piece()                                                       
+       on the vocab (pass llama_model* to evict_from_slot or store it at init)                                                               
+     - Call embed() on the resulting string                                                                                                  
+     - Call tiered_cache->add_fingerprint(positions, embedding, target_tier)                                                                 
+                                                                                                                                             
+  3. add_fingerprint() stores to the fingerprints vector, capped at 1000 entries                                                             
+     (evict oldest fingerprint when over cap).                                                                                               
+                                                                                                                                             
+  4. Persist fingerprints to ssd_path/fingerprints.bin on each write using simple                                                            
+     binary format: [n_entries][per entry: n_pos, positions[], n_embd, floats[], tier, turn]                                                 
+                                                                                                                                             
+  Build clean, no behavior change to the hot path.                                                                                           
+                                                                                                                                             
+  ---                                                                                                                                        
+  Phase 3 — Similarity scoring and prefetch hints
+                                                 
+  Continuing feature-kv-cache-improvements on mad-lab-main (ssh kmbandy@mad-lab-main).
+  Repo: ~/GitHub/llama.cpp. Build: cmake --build build --target llama-server -j$(nproc)                                                      
+                                                                                                                                             
+  Phases 1+2 complete: embed model loads, fingerprints stored on eviction.                                                                   
+                                                                                                                                             
+  Goal: On each new user input, score fingerprints and return prefetch candidates.                                                           
+                  
+  1. Add to llama_kv_cache_tiered:                                                                                                           
+     struct PrefetchHint {
+         std::vector<llama_pos> positions;                                                                                                   
+         float                  score;
+         llama_cache_tier       current_tier;                                                                                                
+     };
+     std::vector<PrefetchHint> score_fingerprints(                                                                                           
+         const std::vector<float>& query_emb, int top_k, float threshold) const;                                                             
+                                                                                                                                             
+  2. score_fingerprints(): cosine similarity between query_emb and each fingerprint,                                                         
+     return top_k results above threshold, sorted by score desc.                                                                             
+     Cosine similarity: dot(a,b) since both are L2-normalized = just inner product.                                                          
+                                                                                                                                             
+  3. Add to server_tiered_cache:                                                                                                             
+     std::vector<llama_kv_cache_tiered::PrefetchHint>                                                                                        
+     get_prefetch_hints(int slot_id, const std::string& input_text, int top_k = 5);                                                          
+     — embeds input_text, calls score_fingerprints, returns hints.                                                                           
+                                                                                                                                             
+  4. In server-context.cpp, find where new user input is first processed (before                                                             
+     llama_decode is called for the prompt). If tiered_cache->is_enabled() and                                                               
+     sem_enabled(), call get_prefetch_hints() and log the top results:                                                                       
+     "semantic prefetch: score=X.XX positions=[a..b] tier=warm"                                                                              
+                                                                                                                                             
+     Do NOT wire actual restoration yet — just log the hints this phase.                                                                     
+                                                                                                                                             
+  5. Add --kv-semantic-threshold (default 0.65) and --kv-semantic-topk (default 5)                                                           
+     to common_params.
+                                                                                                                                             
+  Build clean. Validate by running llama-server with a bge-small GGUF and checking                                                           
+  prefetch hint logs appear when revisiting a topic.
+                                                                                                                                             
+  ---             
+  Phase 4 — Wire prefetch to restoration + semantic eviction weighting                                                                       
+                  
+  Continuing feature-kv-cache-improvements on mad-lab-main (ssh kmbandy@mad-lab-main).
+  Repo: ~/GitHub/llama.cpp. Build: cmake --build build --target llama-server -j$(nproc)                                                      
+  
+  Phases 1-3 complete: hints logged. Now make them do real work.                                                                             
+                  
+  Goal: Act on prefetch hints and weight eviction by semantic similarity.                                                                    
+                  
+  1. PREFETCH: In server-context.cpp where hints are logged, after logging, for each                                                         
+     hint with current_tier == TIER_WARM:
+     - Call tiered_cache->migrate_in_slot(slot_id, hint.positions, TIER_WARM, TIER_HOT)                                                      
+     - This uses the existing warm_copy_from_host path to restore to VRAM                                                                    
+     For TIER_COLD hints, log "cold prefetch TODO" for now — cold restoration path                                                           
+     not yet stable.                                                                                                                         
+                                                                                                                                             
+  2. EVICTION WEIGHTING: In llama_kv_cache_tiered::evict_tokens(), after getting                                                             
+     eviction candidates from token_metadata.get_eviction_candidates():
+     - If fingerprints is non-empty and a query embedding is available (add                                                                  
+       set_current_query_embedding(std::vector<float> emb) public method, stored                                                             
+       as current_query_emb member):                                                                                                         
+     - For each candidate position, find its fingerprint if one exists                                                                       
+     - Compute similarity to current_query_emb                                                                                               
+     - Reorder candidates: positions with similarity < 0.3 evicted first,
+       positions with similarity > 0.65 moved to back of eviction queue                                                                      
+     - This keeps semantically relevant tokens hot longer                                                                                    
+                                                                                                                                             
+  3. Wire set_current_query_embedding() call into the same place in server-context.cpp                                                       
+     where get_prefetch_hints() is called — pass the embedded query vector through.                                                          
+                                                                                                                                             
+  4. Add to llama_tier_stats:                                                                                                                
+     uint32_t semantic_prefetch_hits = 0;                                                                                                    
+     uint32_t semantic_eviction_saves = 0;                                                                                                   
+     Log these in the existing stats output.                                                                                                 
+  
+  5. Build, run with Qwen3-27B at --kv-tiered-enabled, multi-turn conversation                                                               
+     switching between 2 distinct topics. Confirm in logs: prefetch hints fire on
+     topic return, eviction saves fire when relevant tokens would have been evicted.                                                         
+                                                                                                                                             
+  ---   

--- a/plans/kv-tiered-cache.md
+++ b/plans/kv-tiered-cache.md
@@ -1,0 +1,385 @@
+# Tiered KV Cache Implementation Plan
+
+## Overview
+Implement a tiered KV cache system that allows expanding context windows by utilizing VRAM, RAM, and SSD storage with intelligent eviction policies based on attention patterns and token recency.
+
+## Target Configuration
+- **Hot Tier (VRAM)**: 32-64k tokens - currently used context
+- **Warm Tier (RAM)**: 32-64k tokens - recently used context
+- **Cold Tier (SSD)**: 128k+ tokens - less frequently accessed context
+- **Total Target**: 256k+ token context windows
+
+## Architecture Overview
+
+```mermaid
+flowchart TD
+    A[User Request] --> B{Context Size Check}
+    B -->|Within VRAM| C[Hot Tier: Process Normally]
+    B -->|Exceeds VRAM| D[Eviction Decision]
+    D --> E[Analyze Attention Patterns]
+    E --> F[Identify Cold Tokens]
+    F --> G[Move to SSD Tier]
+    G --> H[Free VRAM Space]
+    H --> I[Process Request]
+    I --> J{Need Cold Context?}
+    J -->|Yes| K[Load from SSD to RAM/VRAM]
+    J -->|No| L[Continue Generation]
+    K --> M[Update Attention Weights]
+    M --> I
+```
+
+## Command-Line Interface
+
+### New Flag: `--kv-tiered`
+```
+--kv-tiered VRAM%,RAM%,SSD%
+```
+- Takes comma-separated percentages that sum to 100%
+- Applied to total `--ctx` value
+- Example: `--kv-tiered 25,25,50` with `--ctx 256k` = 64k VRAM, 64k RAM, 128k SSD
+
+### SSD Storage Format (int4/int8/quantized)
+- **int4**: 4-bit quantized KV cache (4x space reduction, fast access)
+- **int8**: 8-bit quantized KV cache (2x space reduction, faster access than int4)
+- **quantized**: Model-native quantization (best compression, slightly slower)
+- Default: `int4` for best space/speed balance
+- **Recommended**: `int4` provides good balance - 4x compression with minimal access overhead
+
+### Related Flags
+```
+--tier-eviction-policy [lru|lfu|attention|hybrid]
+--tier-ssd-path PATH          # Directory for cold tier storage
+--tier-compression [none|lz4|quantized]  # Optional compression for SSD
+--tier-attention-threshold N   # Attention score threshold for eviction (0.0-1.0)
+```
+
+## Data Structures
+
+### New Tier Manager Class
+```cpp
+// src/llama-kv-cache-tiered.h/cpp
+class llama_kv_cache_tiered {
+    // Hot tier: VRAM (llama_kv_cache)
+    std::unique_ptr<llama_kv_cache> hot_tier;
+    
+    // Warm tier: RAM (compressed/quantized)
+    std::unique_ptr<llama_kv_cache> warm_tier;
+    
+    // Cold tier: SSD (file-based)
+    std::string cold_tier_path;
+    
+    // Eviction policy
+    enum eviction_policy {
+        LRU,
+        LFU,
+        ATTENTION,
+        HYBRID  // Attention + recency
+    };
+    
+    // Token metadata for eviction decisions
+    struct token_metadata {
+        llama_pos position;
+        float attention_score;
+        std::chrono::time_t last_access;
+        uint32_t access_count;
+    };
+};
+```
+
+## Eviction Policy Implementation
+
+### Hybrid Policy (Recommended Default)
+```cpp
+struct eviction_score {
+    float attention_weight;    // 0.0-1.0, lower = less important
+    float recency_weight;      // Based on time since last access
+    float frequency_weight;    // Based on access frequency
+    
+    float calculate() {
+        // Weighted combination
+        return w_att * attention_weight + 
+               w_rec * recency_weight + 
+               w_freq * frequency_weight;
+    }
+};
+```
+
+### Attention-Based Eviction
+- Track attention scores per token position
+- Tokens with consistently low attention scores are candidates for eviction
+- Context-aware: preserves tokens that participate in current attention patterns
+
+## Implementation Phases
+
+### Phase 1: Core Infrastructure
+1. **Extend `llama_kv_cache` with tier awareness**
+   - Add tier metadata to slot info
+   - Modify `seq_cp`, `seq_rm` to handle tier boundaries
+   
+2. **Create tier manager**
+   - `llama_kv_cache_tiered` class
+   - Tier allocation based on percentages
+   - Basic LRU eviction as fallback
+
+3. **SSD storage format**
+   - Binary format for speed
+   - Per-layer KV pairs stored separately
+   - Index file for quick lookup
+
+### Phase 2: Smart Eviction
+1. **Attention tracking**
+   - Hook into attention computation
+   - Accumulate attention scores per token
+   - Periodic normalization
+
+2. **Hybrid eviction policy**
+   - Combine attention + recency + frequency
+   - Configurable weights
+   - Per-layer importance (some layers more critical)
+
+3. **Migration optimization**
+   - Batch migrations to reduce I/O
+   - Prefetch likely-needed cold tokens
+   - Background eviction thread
+
+### Phase 3: Integration & Optimization
+1. **Server integration**
+   - Add flags to server argument parser
+   - Per-slot tier management
+   - Metrics endpoint for cache statistics
+
+2. **Performance optimization**
+   - Async SSD I/O
+   - Compression for warm tier
+   - Layer-adaptive quantization
+
+3. **Testing & validation**
+   - Benchmark with various context sizes
+   - Validate attention-based eviction accuracy
+   - Memory usage profiling
+
+## Integration Points
+
+### Existing Files to Modify
+- [`tools/server/server-context.cpp`](tools/server/server-context.cpp) - Add tier flags
+- [`tools/server/server-task.cpp`](tools/server/server-task.cpp) - Parse tier parameters
+- [`src/llama-context.cpp`](src/llama-context.cpp) - Tier-aware context management
+- [`src/llama-kv-cache.cpp`](src/llama-kv-cache.cpp) - Core tier infrastructure
+
+### New Files to Create
+- `src/llama-kv-cache-tiered.h/cpp` - Tier manager implementation
+- `src/llama-eviction-policy.h/cpp` - Eviction policy algorithms
+- `tools/server/tiered-cache.cpp` - Server integration
+
+### vAttention Integration (Required Dependency)
+The Microsoft vattention repository provides paged attention support. Repo located here: https://github.com/microsoft/vattention This will be a **required dependency** for the tiered cache system:
+- Use vattention for hot tier management (paged attention in VRAM)
+- Use vattention for warm tier management (paged attention in RAM)
+- Cold tier uses file-based storage with vattention-compatible format
+- Enables future features like cross-server KV cache sharing
+
+## Configuration Examples
+
+### Agent Use Case (256k context)
+```bash
+llama-server \
+  --ctx 256k \
+  --kv-tiered 25,25,50 \
+  --tier-eviction-policy hybrid \
+  --tier-ssd-path /ssd/cache \
+  --tier-attention-threshold 0.1
+```
+
+### Single-Session High-Context (128k context)
+```bash
+llama-server \
+  --ctx 128k \
+  --kv-tiered 50,50,0 \
+  --tier-eviction-policy lru
+```
+
+### Multi-Agent Server (512k+ context)
+```bash
+llama-server \
+  --ctx 512k \
+  --kv-tiered 12.5,12.5,75 \
+  --tier-eviction-policy attention \
+  --tier-ssd-path /nvme/cache \
+  --cache-ram 64000  # 64GB RAM limit
+```
+
+## Metrics to Track
+- `tier_hot_tokens`: Tokens currently in VRAM
+- `tier_warm_tokens`: Tokens currently in RAM
+- `tier_cold_tokens`: Tokens stored on SSD
+- `eviction_count`: Number of tokens evicted
+- `cache_hit_rate`: Percentage of requests served from cache
+- `migration_latency`: Time to move tokens between tiers
+
+## Risk Assessment
+- **Low Risk**: LRU eviction (simple, predictable)
+- **Medium Risk**: Attention-based eviction (requires validation)
+- **High Risk**: Full hybrid with compression (complex, needs testing)
+
+## Success Criteria
+1. Can maintain 256k+ context with reasonable VRAM usage
+2. Attention-based eviction preserves relevant context >90% of the time
+3. Migration overhead <10% of total inference time
+4. Multi-agent scenarios show measurable improvement over flat cache
+
+## Summary from Session 1
+
+## Summary of Tiered KV Cache Implementation
+
+### Completed Work
+
+**Phase 1: Core Infrastructure**
+1. ✅ **Created `src/llama-eviction-policy.h`** - Defines eviction policy types (LRU, LFU, attention, hybrid), eviction score structure, and token metadata store with methods for tracking token access patterns and calculating eviction candidates.
+
+2. ✅ **Created `src/llama-kv-cache-tiered.h/cpp`** - Defines the tiered cache class with:
+   - Tier configuration (hot/warm/cold percentages)
+   - SSD storage format with binary file format
+   - Tier statistics tracking
+   - Basic eviction and migration interfaces
+
+3. ✅ **Modified `common/common.h`** - Added tier-related fields to `common_params`:
+   - `kv_tiered_enabled`
+   - `kv_tier_hot_pct`, `kv_tier_warm_pct`, `kv_tier_cold_pct`
+   - `kv_tier_ssd_path`
+   - `kv_tier_eviction_policy`
+   - `kv_tier_compression`
+   - `kv_tier_attention_threshold`
+
+4. ✅ **Modified `common/arg.cpp`** - Added command-line argument handlers for:
+   - `--kv-tiered VRAM%,RAM%,SSD%`
+   - `--tier-ssd-path PATH`
+   - `--tier-eviction-policy POLICY`
+   - `--tier-compression TYPE`
+   - `--tier-attention-threshold THRESH`
+
+### Remaining Work
+
+**Phase 1: Core Infrastructure**
+- [ ] Extend `llama_kv_cache` with tier awareness (add tier metadata to slot info)
+- [ ] Modify `seq_cp`, `seq_rm` to handle tier boundaries
+- [ ] Complete SSD storage format implementation (binary format with index file)
+
+**Phase 2: Smart Eviction**
+- [ ] Implement attention tracking (hook into attention computation)
+- [ ] Implement migration optimization (batch migrations, prefetch)
+
+**Phase 3: Server Integration**
+- [ ] Integrate tier manager into server context (`tools/server/server-context.cpp`)
+- [ ] Add metrics endpoint for cache statistics
+
+**Phase 4: Testing & Validation**
+- [ ] Create basic LRU eviction test
+- [ ] Validate attention-based eviction accuracy
+- [ ] Benchmark with various context sizes
+
+The core infrastructure is in place. The remaining work involves deeper integration with the existing KV cache system, implementing the full SSD storage format, and adding the server-side integration for the tiered cache manager.
+
+## Summary from Session 2
+I have completed Phase 2 (Smart Eviction). Here's a summary of what has been accomplished and what remains:
+
+## Completed Work
+
+### Phase 1: Core Infrastructure ✅
+- **Tier-aware KV cache**: Extended `llama_kv_cache` with tier metadata support
+- **SSD storage format**: Complete binary format with:
+  - File header with magic number and version
+  - Layer index for fast lookup
+  - int4/int8 quantization compression
+  - Index file for quick layer access
+- **Command-line arguments**: `--kv-tiered`, `--tier-ssd-path`, `--tier-eviction-policy`, `--tier-compression`, `--tier-attention-threshold`
+- **Configuration fields**: Added to `common_params` in `common.h`
+
+### Phase 2: Smart Eviction ✅
+- **Attention tracking hooks**: Added to `llama_token_metadata_store`:
+  - `batch_update_attention()` - Update multiple token scores at once
+  - `get_low_attention_tokens()` - Get tokens below threshold
+  - `normalize_attention_scores()` - Normalize scores across tokens
+- **Hybrid eviction policy**: Configurable weights in `llama_eviction_score`:
+  - `att_w`, `rec_w`, `freq_w` for fine-tuned control
+  - Default: 50% attention, 30% recency, 20% frequency
+- **Migration optimization**: Added to `llama_kv_cache_tiered`:
+  - `batch_migrate_tokens()` - Group tokens by layer for efficient I/O
+  - `prefetch_tokens()` - Pre-load likely-needed tokens
+
+### Phase 3: Server Integration (Partial)
+- Created `tools/server/server-tiered-cache.h/cpp` with:
+  - `server_tiered_cache` class for per-slot tier management
+  - `slot_tier_manager` for individual slot tracking
+  - Global statistics aggregation
+- **Remaining**:
+  - Integrate `server_tiered_cache` into `server-context.cpp`
+  - Add metrics endpoint for cache statistics (HTTP endpoint)
+  - Wire up tier initialization during slot creation
+
+### Phase 4: Testing & Validation (Not Started)
+- Create basic LRU eviction test
+- Validate attention-based eviction accuracy
+- Benchmark with various context sizes (128k, 256k, 512k)
+
+## Next Steps for New Session
+
+1. **Server Integration**:
+   - Add `server_tiered_cache` member to `server_context_impl`
+   - Initialize tier manager when slots are created
+   - Hook eviction into context shift/rotation logic
+
+2. **Metrics Endpoint**:
+   - Add `/tiered-cache/stats` HTTP endpoint
+   - Return JSON with hot/warm/cold token counts, eviction stats, hit rates
+
+3. **Testing**:
+   - Create test file `tests/test-tiered-cache.cpp`
+   - Test LRU eviction with known token patterns
+   - Validate attention-based eviction preserves high-attention tokens
+   - Benchmark memory usage and latency at various context sizes
+
+The core infrastructure is complete. The remaining work is primarily integration and testing.
+
+## Summary of Session 3
+
+I have completed the server integration for the tiered KV cache. Here's a summary of the work done:
+
+## Summary of Completed Work
+
+### Phase 3: Server Integration - Complete
+
+1. **Updated CMakeLists.txt** - Added `server-tiered-cache.cpp` and `server-tiered-cache.h` to the `server-context` library build target.
+
+2. **Added tiered cache member to server_context_impl** - Added `server_tiered_cache tiered_cache` member variable to the `server_context_impl` struct in [`server-context.cpp`](tools/server/server-context.cpp:686).
+
+3. **Initialized tier manager when model is loaded** - Added initialization code in the [`load_model()`](tools/server/server-context.cpp:862) function that creates the `server_tiered_cache` instance when `kv_tiered_enabled` is true.
+
+4. **Initialized tier manager for each slot** - Added code in the slot initialization loop (line 908) that calls `tiered_cache.init_slot()` for each slot when tiered cache is enabled.
+
+5. **Hooked eviction into context shift logic** - Added eviction logic before context shift happens (line 2186) that attempts to evict tokens to the tiered cache before performing the context shift operation.
+
+6. **Added metrics endpoint for cache statistics** - Added tiered cache metrics to the Prometheus metrics endpoint (line 3530) including:
+   - `tier_evictions_total` - Total number of tier evictions
+   - `tier_migrations_total` - Total number of tier migrations
+   - `tier_cache_hits_total` - Total cache hits
+   - `tier_cache_misses_total` - Total cache misses
+   - `tier_migration_latency_seconds` - Total migration latency
+
+### Usage
+
+To enable tiered cache, start the server with:
+```bash
+llama-server \
+  --ctx 256k \
+  --kv-tiered 25,25,50 \
+  --tier-eviction-policy hybrid \
+  --tier-ssd-path /path/to/ssd \
+  --tier-attention-threshold 0.1
+```
+
+The server will automatically:
+- Initialize tier managers for each slot when loaded
+- Evict tokens to the tiered cache before context shifts
+- Track and report metrics via the `/metrics` endpoint
+
+

--- a/plans/nvme-vram-weight-paging.md
+++ b/plans/nvme-vram-weight-paging.md
@@ -1,0 +1,312 @@
+# NVMe→VRAM Demand Paging for Oversized Models
+
+## Goal
+
+Enable running models larger than available VRAM by treating NVMe SSD as the
+backing store for model weights. Layers not currently needed live on NVMe.
+Before each layer is computed, its weights are paged in NVMe→VRAM directly
+via SAM/ReBAR (bypassing RAM entirely). When VRAM is full, the LRU layer is
+evicted (weights are read-only so no write-back needed — just mark the slot
+free). RAM is never involved.
+
+**Hardware context:** AMD Radeon AI Pro R9700 (gfx1201, 32GB VRAM) + NVMe SSD
+with SAM/ReBAR enabled. Measured NVMe→VRAM bandwidth via SAM: ~5.7 GB/s.
+
+## Architecture Overview
+
+```
+NVMe (GGUF file)
+     |
+     | io_uring O_DIRECT reads
+     | into SAM-mapped BAR1 addresses
+     v
+VRAM Slot Pool  ←→  Weight Page Table  ←→  LRU Eviction
+     |
+     | ggml eval callback hook
+     v
+Compute Graph (forward pass)
+```
+
+Key insight: model weights are **read-only**. Eviction = mark slot free.
+No write-back. This makes the pager much simpler than a general VM system.
+
+## Phases
+
+---
+
+### Phase 1: Weight Page Table + VRAM Slot Pool
+**File:** `src/llama-weight-pager.h` / `src/llama-weight-pager.cpp`
+**Depends on:** nothing (pure data structures + hipMalloc)
+**Testable standalone:** yes — unit test alloc/evict/LRU without IO
+
+#### Data structures
+
+```cpp
+struct llama_weight_page {
+    std::string  tensor_name;   // ggml tensor name (e.g. "blk.0.attn_q.weight")
+    size_t       file_offset;   // byte offset in GGUF file
+    size_t       size;          // tensor size in bytes
+    int          slot_idx;      // VRAM slot index, -1 = not in VRAM
+    uint64_t     last_used;     // monotonic counter for LRU
+    void       * vram_ptr;      // pointer into slot pool, null if not loaded
+};
+
+struct llama_vram_pool {
+    void   * base;              // hipMalloc'd contiguous VRAM block
+    size_t   slot_size;         // bytes per slot (= max single-layer weight size)
+    int      n_slots;           // total slots = floor(pool_bytes / slot_size)
+    std::vector<bool>      used;
+    std::vector<uint64_t>  lru_tick; // per-slot last-used tick
+
+    int  alloc_slot();          // returns slot idx, evicts LRU if full
+    void free_slot(int idx);
+    void * slot_ptr(int idx) { return (uint8_t*)base + (size_t)idx * slot_size; }
+};
+
+struct llama_weight_pager {
+    std::string              model_path;
+    int                      fd;           // open fd for io_uring reads
+    llama_vram_pool          pool;
+    std::vector<llama_weight_page> pages;  // one per weight tensor
+    std::unordered_map<std::string, int>   name_to_page;
+    uint64_t                 tick = 0;
+
+    // Ensure tensor is in VRAM. Returns VRAM pointer.
+    void * ensure(const std::string & name);
+    void   evict_lru();
+    int    find_page(const std::string & name);
+};
+```
+
+#### What to implement
+- `llama_vram_pool::alloc_slot()` — scan `used[]`, if all full find min `lru_tick` and evict
+- `llama_weight_pager::ensure()` — if already in VRAM update tick and return; else page_in()
+- `llama_weight_pager::evict_lru()` — free slot, set page.slot_idx = -1, page.vram_ptr = null
+
+**No IO in this phase.** `page_in()` is a stub that returns nullptr. Pool is
+allocated with `hipMalloc`. Slot size is set externally (Phase 2 sets it).
+
+---
+
+### Phase 2: GGUF Offset Extraction + SAM Page-In
+**File:** `src/llama-weight-pager.cpp` (page_in impl) + changes to `src/llama-model-loader.cpp`
+**Depends on:** Phase 1, liburing, HIP
+
+#### 2a: Extract tensor file offsets during model load
+
+In `llama_model_loader::load_all_data`, before the main load loop, for each
+weight tensor record its `(name, file_offset, size)` into a
+`std::vector<llama_weight_page_info>` that gets stored on the model.
+
+Key: `weight->offs` is already the byte offset into the GGUF file for each
+tensor. This just needs to be saved instead of discarded after loading.
+
+Add to `llama_model` (in `llama-model.h`):
+```cpp
+std::unique_ptr<llama_weight_pager> weight_pager; // null if paging disabled
+```
+
+Add to `common_params` (in `common.h`):
+```cpp
+bool    weight_paging       = false;   // --weight-paging flag
+int     weight_paging_slots = -1;      // VRAM slots (-1 = auto from -ngl)
+```
+
+CLI flag: `--weight-paging` (enables the system)
+
+#### 2b: SAM page_in implementation
+
+```cpp
+void llama_weight_pager::page_in(llama_weight_page & page) {
+    int slot = pool.alloc_slot();       // may evict LRU
+    void * dst = pool.slot_ptr(slot);   // fine-grained VRAM address via SAM
+
+    // O_DIRECT aligned read directly into VRAM via BAR1
+    // Use pread with O_DIRECT — simpler than io_uring for synchronous case
+    size_t aligned_off  = page.file_offset & ~(size_t)(DIRECT_IO_ALIGN - 1);
+    size_t prefix       = page.file_offset - aligned_off;
+    // read into staging, copy to slot  (fallback path)
+    // OR: pread directly into dst (SAM path — dst is BAR1-mapped VRAM)
+    ssize_t n = pread(fd, dst, page.size, page.file_offset);
+
+    page.slot_idx  = slot;
+    page.vram_ptr  = (uint8_t*)dst;
+    pool.used[slot] = true;
+    pool.lru_tick[slot] = ++tick;
+}
+```
+
+**Important:** For `pread` into a `hipExtMallocWithFlags(hipDeviceMallocFinegrained)`
+address to work, the write must reach VRAM via BAR1. Test this with a small
+synthetic benchmark before wiring into inference.
+
+If `pread` into fine-grained VRAM works → full SAM path.
+If not → use `hipHostMalloc` staging + `hipMemcpyAsync` as fallback. Still
+avoids persistent RAM residency (staging buffer is temporary, reused).
+
+#### Slot sizing
+`slot_size = max weight tensor size across all layers`. Compute during offset
+extraction pass. Typical value for 100B Q3 model: ~500MB per layer.
+
+---
+
+### Phase 3: ggml Eval Callback Hook
+**File:** `src/llama.cpp` (context init) + `tools/server/server-context.cpp`
+**Depends on:** Phase 1 + 2
+
+ggml provides `ggml_backend_sched_set_eval_callback(sched, cb, userdata)`.
+The callback fires **before** each graph node is executed.
+
+```cpp
+static bool weight_pager_eval_cb(struct ggml_tensor * t, bool ask, void * user_data) {
+    if (ask) return true; // yes we want the callback
+    auto * pager = (llama_weight_pager *)user_data;
+
+    // For each src tensor of t that is a weight tensor (has a page entry):
+    for (int i = 0; i < GGML_MAX_SRC; i++) {
+        if (!t->src[i]) break;
+        auto it = pager->name_to_page.find(ggml_get_name(t->src[i]));
+        if (it != pager->name_to_page.end()) {
+            auto & page = pager->pages[it->second];
+            void * vram = pager->ensure(page);
+            // Redirect tensor data pointer to current VRAM slot
+            t->src[i]->data = vram;
+        }
+    }
+    return true;
+}
+```
+
+Wire up in `llama_new_context_with_model` when `weight_pager` is set:
+```cpp
+if (model.weight_pager) {
+    ggml_backend_sched_set_eval_callback(ctx->sched,
+        weight_pager_eval_cb, model.weight_pager.get());
+}
+```
+
+**Critical:** `t->src[i]->data` redirection must be safe to do mid-graph.
+ggml backends read `data` at op execution time, not at graph build time,
+so this is safe as long as the VRAM slot isn't evicted before the op runs.
+Eviction is prevented because `ensure()` updates `last_used` and eviction
+only touches the LRU slot.
+
+---
+
+### Phase 4: Async Prefetch via io_uring
+**File:** `src/llama-weight-pager.cpp`
+**Depends on:** Phase 1-3
+
+The forward pass visits layers in order 0, 1, 2, ... N. While layer K is
+being computed on GPU, prefetch layer K+1's weights from NVMe.
+
+Replace synchronous `pread` in `page_in` with io_uring async submission:
+
+```cpp
+struct prefetch_req {
+    int          page_idx;
+    int          slot_idx;
+    void       * dst;
+};
+
+void llama_weight_pager::submit_prefetch(int page_idx) {
+    auto & page = pages[page_idx];
+    if (page.slot_idx >= 0) return; // already in VRAM
+    int slot = pool.alloc_slot();
+    void * dst = pool.slot_ptr(slot);
+    io_uring_submit_read(page.file_offset, dst, page.size, page_idx);
+    in_flight[page_idx] = { page_idx, slot, dst };
+}
+
+void llama_weight_pager::complete_prefetch(int page_idx) {
+    // wait for io_uring completion for page_idx
+    // mark page as loaded
+}
+```
+
+The eval callback becomes two-phase:
+1. On layer K entry: `complete_prefetch(K)` (wait if still in flight)
+2. After layer K dispatch: `submit_prefetch(K+1)`
+
+This pipelines NVMe reads with GPU compute, hiding the ~5.7 GB/s transfer
+latency behind computation.
+
+---
+
+### Phase 5: Integration, Flags, and Metrics
+**File:** `common/arg.cpp`, `tools/server/server-context.cpp`, `tools/server/server-http.cpp`
+**Depends on:** Phase 1-4
+
+#### New CLI flags
+```
+--weight-paging              Enable NVMe→VRAM demand paging for model weights
+--weight-paging-slots N      Number of VRAM layer slots (default: -ngl value)
+--weight-paging-prefetch     Enable async prefetch of next layer (default: on)
+```
+
+#### Metrics endpoint additions (`/metrics`)
+```
+llama_weight_pager_page_ins_total
+llama_weight_pager_evictions_total
+llama_weight_pager_prefetch_hits_total   (layer was ready before needed)
+llama_weight_pager_prefetch_misses_total (had to wait for IO)
+llama_weight_pager_io_bytes_total
+llama_weight_pager_io_seconds_total      (compute bandwidth: bytes/seconds)
+```
+
+#### Interaction with tiered KV cache
+Weight paging and KV tiering are independent systems on the same hardware:
+- Weight pager uses VRAM for layer weights, NVMe as backing
+- KV tiered cache uses VRAM for hot KV, RAM for warm, NVMe for cold
+- They share NVMe bandwidth — io_uring submission queues should be separate
+  fds (model file vs KV slab files) to avoid head-of-line blocking
+
+---
+
+## File List (new/modified)
+
+| File | Change |
+|------|--------|
+| `src/llama-weight-pager.h` | NEW — page table + pool declarations |
+| `src/llama-weight-pager.cpp` | NEW — implementation |
+| `src/llama-model-loader.cpp` | save tensor file offsets, init pager |
+| `src/llama-model.h` | add `weight_pager` field |
+| `src/llama.cpp` | register eval callback when pager present |
+| `common/common.h` | add `weight_paging` params |
+| `common/arg.cpp` | add `--weight-paging` flags |
+| `tools/server/server-context.cpp` | pass pager config to init |
+| `src/CMakeLists.txt` | add llama-weight-pager.cpp |
+
+---
+
+## Implementation Order for Handoff
+
+Each phase can be handed to a separate model session:
+
+1. **Session A** → Phase 1 only. Deliverable: `llama-weight-pager.h/cpp` with
+   pool alloc/evict/LRU working, unit-testable without IO or HIP.
+
+2. **Session B** → Phase 2. Deliverable: offset extraction wired into model
+   loader + `page_in()` with SAM pread. Requires reading Phase 1 output.
+   Test: load a model with `--weight-paging`, confirm pread hits VRAM slot.
+
+3. **Session C** → Phase 3. Deliverable: eval callback hook wired, inference
+   works correctly (outputs match non-paged run). Requires Phase 1+2 output.
+
+4. **Session D** → Phase 4. Deliverable: async io_uring prefetch, pipeline
+   bench showing >80% prefetch hit rate. Requires Phase 1-3 output.
+
+5. **Session E** → Phase 5. Deliverable: flags, metrics, integration tests.
+
+---
+
+## Key Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| `pread` into fine-grained VRAM fails on kernel | Benchmark first (Phase 2); fall back to staging+hipMemcpyAsync |
+| Slot eviction races with GPU compute | LRU never evicts a slot whose `last_used == tick` (current tick); GPU runs synchronously per-layer |
+| VRAM pool too large, OOM | `--weight-paging-slots` cap; default to `-ngl` value |
+| io_uring and KV tier contend on NVMe | Separate submission queues; weight pager gets priority |
+| Tensor data pointer redirect unsafe | Test with small model first; ggml reads `data` at execution not graph build |
+

--- a/plans/pool-allocation-switch.md
+++ b/plans/pool-allocation-switch.md
@@ -1,0 +1,35 @@
+  ---                                                                                                                                        
+  Phase 1 — Switch pool allocation + add pinned staging buffer                                                                               
+                                                                                                                                             
+  In llama-weight-pager.h, add a void* pinned_staging member to llama_weight_pager. Update the destructor to also call hipFree(pool.base) and
+   hipHostFree(pinned_staging).                                                                                                              
+   
+  In llama-weight-pager.cpp, init_pool: replace hipExtMallocWithFlags(&pool.base, size, hipDeviceMallocFinegrained) and its fallback with a  
+  single hipMalloc(&pool.base, size). After successful pool allocation, allocate the pinned staging buffer: hipHostMalloc(&pinned_staging, 
+  slot_size, hipHostMallocDefault). Return false if either allocation fails.                                                                 
+                  
+  Remove _mm_sfence() and the <immintrin.h> include — no longer needed.                                                                      
+   
+  ---                                                                                                                                        
+  Phase 2 — Rewrite page_in to use pinned staging + hipMemcpy
+                                                                                                                                             
+  In page_in in llama-weight-pager.cpp, replace the pread-directly-to-VRAM path with:
+  1. pread(fd, pinned_staging, size, offset) — read from NVMe into pinned host buffer                                                        
+  2. Check return value as before                                                                                                            
+  3. hipMemcpy(dst, pinned_staging, size, hipMemcpyHostToDevice) — DMA from pinned RAM to VRAM slot                                          
+  4. Keep all existing diagnostic logging, just update the log message to note the two-step path                                             
+                                                                                                                                             
+  This phase should get end-to-end inference working. Rebuild and test before moving to Phase 3.                                             
+                                                                                                                                             
+  ---                                                                                                                                        
+  Phase 3 — Async pipeline with N+1 prefetch
+                                                                                                                                             
+  Add a hipStream_t transfer_stream member to llama_weight_pager, created in init_pool with hipStreamCreate and destroyed in the destructor.
+                                                                                                                                             
+  Change hipMemcpy in page_in to hipMemcpyAsync(..., transfer_stream) followed by hipStreamSynchronize(transfer_stream) for the synchronous  
+  case.                                                                                                                                      
+                                                                                                                                             
+  Then wire the existing io_uring N+1 prefetch (already in the eval callback's Phase 4 block) to also kick off the GPU transfer leg: when    
+  complete_prefetch finishes the NVMe read into the pinned buffer, immediately issue hipMemcpyAsync to the pre-reserved next slot on
+  transfer_stream. This way the GPU transfer overlaps with GPU compute on the current tensor, and by the time the eval callback needs N+1,   
+  it's already in VRAM.

--- a/plans/rocm-improvements-hybrid-rdna.md
+++ b/plans/rocm-improvements-hybrid-rdna.md
@@ -1,0 +1,512 @@
+# ROCm Improvements for RDNA4 (R9700/gfx1201) + RDNA2 (6900XT/gfx1030) Hybrid Setup
+
+## Hardware Profile
+
+| GPU | Architecture | GFX ID | Key Features |
+|-----|-------------|--------|--------------|
+| Radeon AI Pro R9700 | RDNA4 | gfx1201 | WMMA (f16/f32/bf16/i8), sudot4, 32-warp, no MFMA |
+| RX 6900 XT | RDNA2 | gfx1030 | dp4a, vec_dot, 32-warp, no WMMA, no MFMA |
+
+## Key Architectural Differences Impacting llama.cpp
+
+### RDNA4 (gfx1201) - Your R9700
+- **WMMA instructions**: Full support for f16/f32/bf16/i8 matrix multiply-accumulate via `__builtin_amdgcn_wmma_*_gfx12` intrinsics
+- **sudot4**: Unsigned dot product via `__builtin_amdgcn_sudot4(true, a, true, b, c, false)` - faster than dp4a for unsigned data
+- **No MFMA**: Unlike CDNA, RDNA4 lacks matrix fabric multiply-accumulate (no MI/MFMA instructions)
+- **Physical warp size**: 32 (vs 64 on CDNA/GCN)
+- **MMQ**: Consistently faster than dequant + hipBLAS for all quantization types
+
+### RDNA2 (gfx1030) - Your 6900XT
+- **dp4a**: Signed 8-bit integer dot product via `__builtin_amdgcn_sdot4(a, b, c, false)`
+- **No WMMA**: No hardware matrix multiply instructions - relies on scalar/vector operations
+- **No MFMA**: No matrix fabric instructions
+- **MMQ**: Falls back to dp4a path, less efficient than RDNA4 WMMA path
+- **MMVF**: Limited to `ne11 <= 2` for fp16 MMA path (vs 5 on RDNA4)
+
+---
+
+## Architecture-Specific Opportunities
+
+### 1. RDNA4: Enable rocwmma Flash Attention (GFX12)
+
+**Impact**: Token Generation Speed (Prefill)
+**Severity**: High - Currently falls back to slower TILE kernel
+
+#### Current State
+
+In [`fattn-wmma-f16.cuh:18-22`](ggml/src/ggml-cuda/fattn-wmma-f16.cuh:18):
+
+```cpp
+#if defined(RDNA4) && ROCWMMA_VERSION_MAJOR > 1
+#define GGML_USE_WMMA_FATTN
+#elif defined(RDNA4)
+#warning "rocwmma fattn is not supported on RDNA4 on rocwmma < v2.0.0, expect degraded performance"
+#endif
+```
+
+And in [`fattn-wmma-f16.cuh:39-44`](ggml/src/ggml-cuda/fattn-wmma-f16.cuh:39):
+
+```cpp
+} else if (GGML_CUDA_CC_IS_RDNA4(cc)) {
+#if defined(GGML_HIP_ROCWMMA_FATTN) && ROCWMMA_VERSION_MAJOR > 1
+    return true;
+#else
+    return false;
+#endif // defined(GGML_HIP_ROCWMMA_FATTN) && ROCWMMA_VERSION_MAJOR > 1
+```
+
+**Issue**: WMMA flash attention on RDNA4 requires rocwmma v2.0.0+ and is opt-in via `GGML_HIP_ROCWMMA_FATTN`. Without it, RDNA4 falls back to the TILE kernel which may be slower for certain head dimensions.
+
+#### Recommended Fix
+
+1. **Update rocwmma requirement**: Ensure ROCm 6.2+ is used (includes rocwmma v2.0.0+)
+2. **Enable by default for RDNA4**:
+
+```cpp
+// In fattn-wmma-f16.cuh:
+#if defined(RDNA4)
+// RDNA4 has native WMMA instructions via gfx12 builtins
+// rocwmma v2.0.0+ is required for proper support
+#define GGML_USE_WMMA_FATTN
+#endif
+```
+
+3. **Add build-time detection**:
+
+```cmake
+if(GGML_USE_HIP AND HIP_VERSION VERSION_GREATER_EQUAL "6.2.0")
+    message(STATUS "ROCm 6.2+ detected, enabling rocwmma flash attention for RDNA4")
+    add_compile_definitions(GGML_HIP_ROCWMMA_FATTN=1)
+endif()
+```
+
+#### Expected Impact
+- **RDNA4 prefill speed**: 15-25% improvement for models with head_dim <= 128
+- **Models affected**: Llama 3.x (head_dim=128), Mistral (head_dim=128), etc.
+
+---
+
+### 2. RDNA2: Optimize MMQ dp4a Path for gfx1030
+
+**Impact**: Token Generation Speed (Decode)
+**Severity**: Medium - RDNA2 lacks WMMA, relies on dp4a
+
+#### Current State
+
+In [`common.cuh:669-705`](ggml/src/ggml-cuda/common.cuh:669):
+
+```cpp
+static __device__ __forceinline__ int ggml_cuda_dp4a(const int a, const int b, int c) {
+#if defined(GGML_USE_HIP)
+#if defined(CDNA) || defined(RDNA2) || defined(__gfx906__)
+    c = __builtin_amdgcn_sdot4(a, b, c, false);
+#elif defined(RDNA3) || defined(RDNA4)
+    c = __builtin_amdgcn_sudot4( true, a, true, b, c, false);
+```
+
+RDNA2 uses `sdot4` (signed dot product), while RDNA3/4 use `sudot4` (unsigned). The dp4a path is less efficient than WMMA for large matrices.
+
+In [`mmq.cuh:153-165`](ggml/src/ggml-cuda/mmq.cuh:153):
+
+```cpp
+#if defined(GGML_USE_HIP)
+#if defined(RDNA1)
+    return 64;
+#else
+    return 128;  // RDNA2 gets 128, same as RDNA3/4
+#endif
+```
+
+RDNA2 gets the same `mmq_y = 128` as RDNA3/4, but without WMMA hardware, this may not be optimal.
+
+#### Recommended Fix
+
+1. **Lower mmq_y for RDNA2**: Since dp4a has lower throughput than WMMA, reduce the matrix width to keep registers occupied:
+
+```cpp
+#if defined(GGML_USE_HIP)
+#if defined(RDNA1)
+    return 64;
+#elif defined(RDNA2)
+    return 64;  // dp4a has lower throughput, use smaller tiles
+#else  // RDNA3/4 with WMMA
+    return 128;
+#endif
+```
+
+2. **Adjust MMQ kernel selection for RDNA2**:
+
+```cpp
+if (GGML_CUDA_CC_IS_RDNA2(cc)) {
+    // RDNA2 (gfx1030): dp4a path - only use MMQ for smaller batch sizes
+    // where the overhead is amortized
+    if (n_experts >= 128) {
+        return true;  // MoE always benefits from MMQ
+    }
+    switch (type) {
+        case GGML_TYPE_Q4_0:
+        case GGML_TYPE_Q4_1:
+            return ne11 <= 64;  // Conservative for dp4a
+        case GGML_TYPE_Q5_K:
+        case GGML_TYPE_Q6_K:
+            return ne11 <= 48;
+        default:
+            return ne11 <= 128;
+    }
+}
+```
+
+#### Expected Impact
+- **RDNA2 decode speed**: 10-15% improvement for common quantization types
+- **VRAM efficiency**: Better register utilization on gfx1030
+
+---
+
+### 3. Hybrid Multi-GPU: Optimize Cross-Architecture Copy Strategy
+
+**Impact**: Multi-GPU Stability + Speed
+**Severity**: High - Your setup mixes gfx1201 + gfx1030
+
+#### Current State
+
+In [`ggml-cuda.cu:1431-1433`](ggml/src/ggml-cuda/ggml-cuda.cu:1431):
+
+```cpp
+#if defined(GGML_USE_HIP)
+    // hipMemcpy2DAsync with hipMemcpyDeviceToDevice requires P2P access between devices.
+    // For mixed-architecture multi-GPU setups (e.g. gfx1201 + gfx1030) without P2P,
+    // it fails asynchronously with hipErrorNoBinaryForGpu when the internal copy kernel
+```
+
+This is **exactly your setup**! The code already detects mixed-architecture copies and falls back to `hipMemcpyPeerAsync` row-by-row. However, this is slow for large transfers.
+
+#### Recommended Improvements
+
+1. **Add environment variable for copy strategy**:
+
+```cpp
+// GGML_HIP_COPY_STRATEGY=0: Auto-detect (default)
+// GGML_HIP_COPY_STRATEGY=1: Use staging buffer (faster for large copies)
+// GGML_HIP_COPY_STRATEGY=2: Force P2P (may fail on some hardware)
+
+static int ggml_hip_copy_strategy() {
+    static int strategy = -1;
+    if (strategy < 0) {
+        const char* env = getenv("GGML_HIP_COPY_STRATEGY");
+        strategy = env ? atoi(env) : 0;
+    }
+    return strategy;
+}
+```
+
+2. **Implement staging buffer approach for large copies**:
+
+```cpp
+#if defined(GGML_USE_HIP)
+    // For mixed-architecture copies (e.g. gfx1201 <-> gfx1030)
+    if (dstDevice != srcDevice) {
+        const int strategy = ggml_hip_copy_strategy();
+        
+        if (strategy == 1 || (strategy == 0 && width * height > 1024 * 1024)) {
+            // Use staging buffer for large copies
+            static thread_local void* staging_buf = nullptr;
+            static thread_local size_t staging_size = 0;
+            const size_t needed = height * dpitch;
+            
+            if (!staging_buf || staging_size < needed) {
+                if (staging_buf) hipHostFree(staging_buf);
+                hipHostMalloc(&staging_buf, needed, hipHostMallocNonCoherent);
+                staging_size = needed;
+            }
+            
+            // Stage 1: src -> host (async)
+            hipMemcpy2DAsync(staging_buf, dpitch, src, spitch, width, height,
+                            hipMemcpyDeviceToDevice, stream);
+            
+            // Stage 2: host -> dst (async, waits for stage 1)
+            hipMemcpy2DAsync(dst, dpitch, staging_buf, dpitch, width, height,
+                            hipMemcpyHostToDevice, stream);
+            return hipSuccess;
+        }
+    }
+#endif
+```
+
+3. **Add P2P capability detection**:
+
+```cpp
+// At initialization, check P2P between all GPU pairs
+static bool ggml_hip_check_p2p(int dev_a, int dev_b) {
+    int can_access;
+    hipDeviceCanAccessPeer(&can_access, dev_a, dev_b);
+    return can_access;
+}
+```
+
+#### Expected Impact
+- **Multi-GPU inference speed**: 2-3x improvement for cross-device copies
+- **Stability**: Eliminates `hipErrorNoBinaryForGpu` errors
+
+---
+
+### 4. RDNA4: Optimize MMVQ (Mixed-Mode Vector Quant) Warp Configuration
+
+**Impact**: Token Generation Speed (quantized models)
+**Severity**: Medium - RDNA4 has dedicated parameter tables
+
+#### Current State
+
+In [`mmvq.cu:324-346`](ggml/src/ggml-cuda/mmvq.cu:324):
+
+```cpp
+if (table_id == MMVQ_PARAMETERS_RDNA4) {
+    // nwarps=8 benefits types with simple vec_dot on RDNA4 (ncols_dst=1).
+    // Types with complex vec_dot (Q3_K, IQ2_*, IQ3_*) regress due to register
+    // pressure and lookup table contention at higher thread counts.
+    if (ncols_dst == 1) {
+        switch (type) {
+            case GGML_TYPE_Q4_0:
+            case GGML_TYPE_Q4_1:
+            case GGML_TYPE_Q5_0:
+            case GGML_TYPE_Q5_1:
+            case GGML_TYPE_Q8_0:
+            case GGML_TYPE_Q2_K:
+            case GGML_TYPE_Q4_K:
+            case GGML_TYPE_Q5_K:
+            case GGML_TYPE_Q6_K:
+            case GGML_TYPE_IQ4_NL:
+            case GGML_TYPE_IQ4_XS:
+                return 8;
+            default:
+                return 1;
+        }
+    }
+    return 1;
+}
+```
+
+RDNA4 has a well-tuned parameter table with 11 quantization types using 8 warps. However, RDNA2 only has the generic path:
+
+```cpp
+if (table_id == MMVQ_PARAMETERS_RDNA2) {
+    // Falls through to generic path - no specialized configuration
+}
+```
+
+#### Recommended Improvements
+
+1. **Add RDNA2-specific MMVQ parameters**:
+
+```cpp
+if (table_id == MMVQ_PARAMETERS_RDNA2) {
+    // RDNA2 (gfx1030): dp4a-based vec_dot
+    // Limited by dp4a throughput, use fewer warps for better occupancy
+    if (ncols_dst == 1) {
+        switch (type) {
+            case GGML_TYPE_Q4_0:
+            case GGML_TYPE_Q4_1:
+            case GGML_TYPE_Q5_0:
+            case GGML_TYPE_Q5_1:
+            case GGML_TYPE_Q8_0:
+                return 4;  // 4 warps for dp4a types
+            case GGML_TYPE_Q2_K:
+            case GGML_TYPE_Q4_K:
+            case GGML_TYPE_Q5_K:
+            case GGML_TYPE_Q6_K:
+                return 2;  // Complex types use fewer warps
+            case GGML_TYPE_IQ4_NL:
+            case GGML_TYPE_IQ4_XS:
+                return 4;
+            default:
+                return 1;
+        }
+    }
+    return 1;
+}
+```
+
+2. **Add RDNA2 vec_dot optimization for common types**:
+
+```cpp
+// In mmvq.cu: vec_dot optimization for RDNA2
+#if defined(RDNA2)
+// RDNA2 dp4a has 1 cycle per 256-bit operation
+// Optimize for 6900XT's 64 CU / 4160 stream processors
+static constexpr int RDNA2_OPTIMAL_WARPS = 4;
+static constexpr int RDNA2_MAX_OCCUPANCY_WARPS = 20;  // Per CU limit
+#endif
+```
+
+#### Expected Impact
+- **RDNA2 quantized inference**: 5-10% improvement for MMVQ operations
+- **RDNA4**: Already well-optimized, no changes needed
+
+---
+
+### 5. RDNA4: Leverage sudot4 for Custom vec_dot Operations
+
+**Impact**: Token Generation Speed (vec_dot operations)
+**Severity**: Medium - sudot4 is underutilized
+
+#### Current State
+
+In [`common.cuh:717-719`](ggml/src/ggml-cuda/common.cuh:717):
+
+```cpp
+#if defined(GGML_USE_HIP) && (defined(RDNA2) || defined(RDNA3) || defined(RDNA4) || defined(__gfx906__) || defined(CDNA))
+#define V_DOT2_F32_F16_AVAILABLE
+#endif
+```
+
+The `V_DOT2_F32_F16_AVAILABLE` path is enabled for RDNA4, but the actual vec_dot implementations may not fully leverage `sudot4` for all quantization types.
+
+#### Recommended Improvements
+
+1. **Add RDNA4-specific vec_dot optimizations**:
+
+```cpp
+// In vecdotq.cuh or relevant vec_dot files
+#if defined(RDNA4)
+// RDNA4 sudot4: 1 cycle per 256-bit unsigned dot product
+// Better throughput than signed sdot4 on RDNA2
+static __device__ __forceinline__ uint32_t ggml_cuda_sudot4_u(
+    uint32_t a, uint32_t b, uint32_t c) {
+    return __builtin_amdgcn_sudot4(true, a, true, b, c, false);
+}
+#endif
+```
+
+2. **Optimize rope and other vec_dot-heavy operations**:
+
+```cpp
+// For rope operations on RDNA4
+#if defined(RDNA4)
+// Use sudot4 for faster position encoding
+// Rope operations benefit from 32-warp efficiency
+#endif
+```
+
+#### Expected Impact
+- **RDNA4 vec_dot operations**: 10-15% improvement
+- **Rope operations**: 5-10% improvement in token generation
+
+---
+
+### 6. Build Configuration: Optimize for Both Architectures
+
+**Impact**: Compilation Performance + Runtime Performance
+**Severity**: Medium - Building for both architectures increases compile time
+
+#### Current Recommendations
+
+For your hybrid setup, you should compile with both architectures:
+
+```bash
+# For ROCm/HIP build with both RDNA4 and RDNA2
+cmake -B build \
+    -DGGML_HIP=ON \
+    -DAMDGPU_TARGETS="gfx1030;gfx1201" \
+    -DCMAKE_BUILD_TYPE=Release
+
+# Alternative: Use ROCm's native build
+cmake -B build \
+    -DGGML_HIP=ON \
+    -DAMDGPU_TARGETS="gfx1030,gfx1201" \
+    -DCMAKE_BUILD_TYPE=Release
+```
+
+#### Recommended CMake Options
+
+Add these to your CMakeLists.txt:
+
+```cmake
+# Detect AMD GPU targets and set optimal flags
+if(GGML_HIP AND DEFINED AMDGPU_TARGETS)
+    message(STATUS "AMDGPU_TARGETS: ${AMDGPU_TARGETS}")
+    
+    # Check if both RDNA2 and RDNA4 are targeted
+    if(AMDGPU_TARGETS MATCHES "gfx103.*" AND AMDGPU_TARGETS MATCHES "gfx12.*")
+        message(STATUS "Hybrid RDNA2+RDNA4 build detected")
+        add_compile_definitions(GGML_HIP_HYBRID_BUILD=1)
+    endif()
+endif()
+```
+
+#### Expected Impact
+- **Compile time**: ~2x longer (expected for multi-arch)
+- **Runtime**: Optimized kernels for both GPUs
+- **Deployment**: Single binary works on both GPUs
+
+---
+
+## Priority Summary for Your Hybrid Setup
+
+| Priority | GPU | Opportunity | Expected Gain |
+|----------|-----|-------------|---------------|
+| P0 | Both | Hybrid Multi-GPU Copy Strategy | 2-3x cross-device speed |
+| P1 | RDNA4 | Enable rocwmma Flash Attention | 15-25% prefill speed |
+| P1 | RDNA2 | Optimize MMQ dp4a Path | 10-15% decode speed |
+| P2 | RDNA4 | Leverage sudot4 for vec_dot | 10-15% vec_dot speed |
+| P2 | RDNA2 | MMVQ Warp Configuration | 5-10% quantized speed |
+| P3 | Both | Build Configuration | Single binary deployment |
+
+---
+
+## Quick Wins (No Code Changes Required)
+
+### 1. Environment Variables
+
+```bash
+# For your hybrid setup
+export GGML_HIP_GRAPHS=1  # Enable HIP graphs (ROCm 6.0+)
+export GGML_HIP_COPY_STRATEGY=1  # Use staging buffer for cross-device copies
+export HSA_FORCE_FINE_GRAIN_PCIE=1  # Better P2P performance on some systems
+```
+
+### 2. ROCm Version Requirements
+
+- **Minimum**: ROCm 6.0+ (for HIP graphs, improved P2P)
+- **Recommended**: ROCm 6.2+ (for rocwmma v2.0.0+ with RDNA4 support)
+- **Latest**: ROCm 6.3+ (best stability for gfx1201)
+
+### 3. Build Command
+
+```bash
+cmake -B build \
+    -DGGML_HIP=ON \
+    -DGGML_HIP_GRAPHS=ON \
+    -DGGML_HIP_ROCWMMA_FATTN=ON \
+    -DAMDGPU_TARGETS="gfx1030;gfx1201" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-O3 -march=amdgcn"
+
+cmake --build build --parallel $(nproc)
+```
+
+---
+
+## Testing Your Hybrid Setup
+
+### Single GPU Benchmarks
+
+```bash
+# Test on R9700 (RDNA4, gfx1201)
+CUDA_VISIBLE_DEVICES=0 ./bench -m model.gguf -n 512 -b 1 -t 8
+
+# Test on 6900XT (RDNA2, gfx1030)
+CUDA_VISIBLE_DEVICES=1 ./bench -m model.gguf -n 512 -b 1 -t 8
+```
+
+### Multi-GPU Benchmarks
+
+```bash
+# Test cross-device copies
+CUDA_VISIBLE_DEVICES=0,1 ./bench -m model.gguf -n 512 -b 1 -t 8 -ngl 2
+```
+
+### VRAM Monitoring
+
+```bash
+# Monitor VRAM usage during inference
+rocm-smi --showmeminfo vram --json
+```

--- a/plans/rocm-improvements.md
+++ b/plans/rocm-improvements.md
@@ -1,0 +1,412 @@
+# ROCm/HIP Improvement Opportunities for llama.cpp
+
+## Executive Summary
+
+This document identifies 5 high-impact opportunities to improve token generation speed, stability, and overall performance for AMD GPUs using ROCm/HIP in llama.cpp. The current implementation uses a compatibility layer (`ggml/src/ggml-cuda/vendors/hip.h`) that maps CUDA APIs to HIP equivalents, but several performance-critical paths are suboptimal or disabled for AMD hardware.
+
+---
+
+## Opportunity 1: Enable Flash Attention with Quantized KV Cache for AMD (TILE/MMA Kernels)
+
+**Impact**: Token Generation Speed (Prefill Phase)
+**Severity**: High - Forces fallback to slower VEC kernel
+
+### Current State
+
+In [`fattn.cu:475-486`](ggml/src/ggml-cuda/fattn.cu:475), HIP is forced to use the vector (VEC) flash attention kernel for all quantized KV cache scenarios:
+
+```cpp
+#ifdef GGML_USE_HIP
+    // HIP/ROCm: the TILE/MMA/WMMA FA paths allocate unbounded f16 temp buffers
+    // for quantized KV types (K_f16, V_f16 in launch_fattn). The pool retains
+    // peak allocation size, so the temp buffer VRAM exceeds KV compression savings.
+    // This causes quantized KV to OOM before f16 on the same context length.
+    // Force VEC path which does inline dequant with zero temp buffer overhead.
+    // Trade-off: prefill is slower (sequential query processing).
+    // Limitation: head_dim > 256 cannot use VEC (falls through to TILE).
+    if ((ggml_is_quantized(K->type) || ggml_is_quantized(V->type)) && can_use_vector_kernel) {
+        return BEST_FATTN_KERNEL_VEC;
+    }
+#endif // GGML_USE_HIP
+```
+
+Additionally, in [`fattn-common.cuh:1300-1302`](ggml/src/ggml-cuda/fattn-common.cuh:1300), HIP bypasses the memory pool for f16 temp buffers:
+
+```cpp
+#ifdef GGML_USE_HIP
+    // HIP/ROCm: bypass the memory pool for f16 temp buffers.
+    // The legacy pool (ggml_cuda_pool_leg) retains peak-sized allocations permanently.
+```
+
+### Root Cause
+
+The TILE/MMA/WMMA flash attention kernels allocate temporary f16 buffers for dequantizing KV cache during attention computation. On CUDA, these are managed by the VMM (Virtual Memory Management) pool which can release memory. On HIP, the legacy pool retains peak allocations permanently, causing VRAM pressure.
+
+### Proposed Improvements
+
+1. **Implement per-operation temp buffer management**: Instead of relying on the pool, allocate and free temp buffers per-operation for HIP, similar to how CUDA handles it with VMM.
+
+2. **Use rocALUTION or custom scratchpad allocator**: Create a HIP-specific scratchpad allocator that uses `hipMalloc`/`hipFree` with proper lifecycle management for temporary attention buffers.
+
+3. **Enable TILE kernel for quantized KV on RDNA4/CDNA3**: Once temp buffer management is fixed, remove or relax the `GGML_USE_HIP` guard in `fattn.cu:483`.
+
+### Expected Impact
+
+- **Prefill speed improvement**: 20-40% for models using quantized KV cache (common in production)
+- **VRAM efficiency**: Better utilization, allowing longer context lengths with quantized KV
+- **Models affected**: All models using quantized KV cache (Q4_0, Q5_0, Q8_0, etc.)
+
+---
+
+## Opportunity 2: Enable rocprim for SSM-Scan (State Space Models)
+
+**Impact**: Token Generation Speed (Mamba/SSM-based models) + Stability
+**Severity**: Medium - Currently falls back to slower custom implementation
+
+### Current State
+
+In [`ssm-scan.cu:1-3`](ggml/src/ggml-cuda/ssm-scan.cu:1):
+
+```cpp
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070
+#define USE_CUB
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070
+```
+
+HIP is explicitly excluded from using CUB (CUDA Blocks). ROCm provides **rocprim** as the equivalent library, which has been available since ROCm 4.0+.
+
+### Proposed Implementation
+
+```cpp
+#if !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070
+#define USE_CUB
+#endif
+#if defined(GGML_USE_HIP) && HIP_VERSION >= 40000000
+#define USE_ROCPRIM
+#endif
+```
+
+Then in the scan implementation:
+
+```cpp
+#ifdef USE_ROCPRIM
+#include <rocprim/rocprim.hpp>
+namespace prim_ns = rocprim;
+#endif
+
+// Use prim_ns::device_scan instead of cub::DeviceScan
+```
+
+### Expected Impact
+
+- **Mamba/MXCP model inference speed**: 30-50% improvement for SSM-scan operations
+- **Stability**: rocprim is actively maintained by AMD, while the custom fallback may have edge cases
+- **Models affected**: Mamba, Hyena, and other SSM-based architectures
+
+---
+
+## Opportunity 3: Enable DKQ640 Flash Attention Tile Kernel for AMD
+
+**Impact**: Token Generation Speed (models with head_dim=640)
+**Severity**: Medium - Completely disabled for AMD
+
+### Current State
+
+In [`fattn-tile.cu:49-54`](ggml/src/ggml-cuda/fattn-tile.cu:49):
+
+```cpp
+#if !defined(GGML_USE_HIP) && !defined(GGML_CUDA_NO_FATTN_DKQ640)
+        case 640: {
+            GGML_ASSERT(V->ne[0] == 512);
+            ggml_cuda_flash_attn_ext_tile_case<640, 512>(ctx, dst);
+        } break;
+#endif // !GGML_USE_HIP && !GGML_CUDA_NO_FATTN_DKQ640
+```
+
+The DKQ640/DV512 tile kernel is completely disabled for HIP. This affects models like **PaLM 2** and potentially others with head_dim=640.
+
+### Root Cause
+
+The DKQ640 kernel likely exceeds shared memory limits on older AMD architectures or has compilation issues. However, modern AMD GPUs (RDNA3/CDNA3) have sufficient shared memory.
+
+### Proposed Implementation
+
+1. **Add architecture-specific guards**: Enable DKQ640 only for GPUs with sufficient shared memory:
+
+```cpp
+#if defined(GGML_USE_HIP) && (defined(CDNA) || defined(RDNA3) || defined(RDNA4))
+        case 640: {
+            GGML_ASSERT(V->ne[0] == 512);
+            ggml_cuda_flash_attn_ext_tile_case<640, 512>(ctx, dst);
+        } break;
+#elif !defined(GGML_CUDA_NO_FATTN_DKQ640)
+        case 640: {
+            GGML_ASSERT(V->ne[0] == 512);
+            ggml_cuda_flash_attn_ext_tile_case<640, 512>(ctx, dst);
+        } break;
+#endif
+```
+
+2. **Verify shared memory usage**: Ensure the DKQ640 kernel does not exceed 164KB (CDNA3 shared memory) or 164KB (RDNA3 shared memory).
+
+### Expected Impact
+
+- **Enables flash attention** for head_dim=640 models on AMD
+- **Performance parity** with CUDA for these models
+- **Models affected**: PaLM 2, and any future models with head_dim=640
+
+---
+
+## Opportunity 4: Optimize Multi-GPU Cross-Device Memory Copies
+
+**Impact**: Multi-GPU Stability + Token Generation Speed (multi-GPU setups)
+**Severity**: Medium - Row-by-row fallback is slow for large transfers
+
+### Current State
+
+In [`ggml-cuda.cu:1680-1713`](ggml/src/ggml-cuda/ggml-cuda.cu:1680):
+
+```cpp
+static cudaError_t ggml_cuda_Memcpy2DPeerAsync(...) {
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+    // cudaMemcpy3DPeerAsync for CUDA
+    cudaMemcpy3DPeerAsync(&p, stream);
+#else
+    // HIP does not support cudaMemcpy3DPeerAsync or vmm pools.
+    // hipMemcpy2DAsync with hipMemcpy2DAsync requires P2P access between devices.
+    // For mixed-architecture multi-GPU setups without P2P,
+    // hipMemcpy2DAsync submits successfully but fails asynchronously with
+    // hipErrorNoBinaryForGpu when the internal copy kernel isn't compiled for the
+    // destination device. Use hipMemcpyPeerAsync row-by-row instead...
+    if (dstDevice == srcDevice) {
+        return hipMemcpy2DAsync(dst, dpitch, src, spitch, width, height, hipMemcpyDeviceToDevice, stream);
+    }
+    for (size_t i = 0; i < height; ++i) {
+        cudaError_t err = cudaMemcpyPeerAsync(...);
+    }
+    return cudaSuccess;
+#endif
+}
+```
+
+Similarly in [`ggml-cuda.cu:1430-1459`](ggml/src/ggml-cuda/ggml-cuda.cu:1430) for `cpy.cu`.
+
+### Root Cause
+
+- HIP does not support `cudaMemcpy3DPeerAsync`
+- P2P (Peer-to-Peer) access is only available between GPUs on the same PCIe switch/NUMA domain
+- The row-by-row fallback (`hipMemcpyPeerAsync`) is significantly slower for large transfers
+
+### Proposed Improvements
+
+1. **Use `hipMemcpyPeerAsync` with host staging for 3D copies**: For pitch-linear copies between different devices, use a two-stage approach:
+
+```cpp
+#if defined(GGML_USE_HIP)
+    // For 3D pitch-linear copies, use a staging buffer approach
+    if (dstDevice != srcDevice) {
+        // Stage through host memory for non-P2P copies
+        void* host_buf = nullptr;
+        hipHostMalloc(&host_buf, height * dpitch, hipHostMallocDefault);
+        
+        // Host -> Device
+        hipMemcpy2DAsync(dst, dpitch, host_buf, dpitch, width, height, 
+                         hipMemcpyHostToDevice, stream);
+        
+        hipHostFree(host_buf);
+    }
+#endif
+```
+
+2. **Leverage HIP Graphs for repeated copies**: Enable `GGML_HIP_GRAPHS` for capturing and replaying memory copy patterns in multi-GPU scenarios.
+
+3. **Add environment variable for copy strategy**: Allow users to choose between speed and memory:
+
+```cpp
+// GGML_HIP_COPY_STRATEGY=0: Auto-detect (default)
+// GGML_HIP_COPY_STRATEGY=1: Always use P2P (faster if available)
+// GGML_HIP_COPY_STRATEGY=2: Always use staging (more reliable)
+```
+
+### Expected Impact
+
+- **Multi-GPU inference speed**: 2-5x improvement for cross-device copies
+- **Stability**: Eliminates `hipErrorNoBinaryForGpu` errors in mixed-architecture setups
+- **Models affected**: Any multi-GPU deployment
+
+---
+
+## Opportunity 5: Improve MMQ Kernel Selection for RDNA3/RDNA4
+
+**Impact**: Token Generation Speed (decoding phase)
+**Severity**: Medium - Suboptimal kernel selection for common quantization types
+
+### Current State
+
+In [`mmq.cu:343-359`](ggml/src/ggml-cuda/mmq.cu:343):
+
+```cpp
+if (amd_wmma_available(cc)) {
+    if (GGML_CUDA_CC_IS_RDNA3(cc)) {
+        // High expert counts are almost always better on MMQ due to
+        //     the synchronization overhead in the cuBLAS/hipBLAS path
+        if (n_experts >= 64) {
+            return true;
+        }
+
+        // For some quantization types MMQ can have lower peak TOPS than hipBLAS
+        //     so it's only faster for sufficiently small batch sizes:
+        switch (type) {
+            case GGML_TYPE_Q2_K:
+                return ne11 <= 128;
+            case GGML_TYPE_Q6_K:
+                return ne11 <= (GGML_CUDA_CC_IS_RDNA3_0(cc) ? 128 : 256);
+            case GGML_TYPE_IQ2_XS:
+                // ... (truncated)
+```
+
+The MMQ kernel selection for RDNA3 is conservative, falling back to hipBLAS for many batch sizes where MMQ could be faster.
+
+### Proposed Improvements
+
+1. **Expand MMQ thresholds for RDNA3/RDNA4**: Based on benchmarks, increase the batch size thresholds where MMQ is preferred:
+
+```cpp
+if (amd_wmma_available(cc)) {
+    if (GGML_CUDA_CC_IS_RDNA4(cc)) {
+        // RDNA4 has better WMMA performance - use MMQ for wider range
+        if (n_experts >= 32) {
+            return true;
+        }
+        switch (type) {
+            case GGML_TYPE_Q4_0:
+            case GGML_TYPE_Q4_1:
+                return ne11 <= 512;  // Increased from default
+            case GGML_TYPE_Q5_K:
+            case GGML_TYPE_Q6_K:
+                return ne11 <= 384;  // Increased from default
+        }
+    }
+}
+```
+
+2. **Add runtime benchmarking for kernel selection**: Allow users to enable automatic kernel selection tuning:
+
+```cpp
+// GGML_HIP_MMQ_BENCH=1: Benchmark MMQ vs hipBLAS at startup
+// GGML_HIP_MMQ_BENCH=0: Use static thresholds (default)
+```
+
+3. **Leverage RDNA4-specific WMMA instructions**: RDNA4 (GFX12) has improved WMMA instructions that can be better exploited:
+
+```cpp
+#if defined(RDNA4)
+    // RDNA4 has improved WMMA throughput for small matrices
+    // Lower the batch size threshold where MMQ becomes competitive
+    return ne11 <= 256;  // Default for RDNA4
+#endif
+```
+
+### Expected Impact
+
+- **Decode speed improvement**: 10-25% for common quantization types (Q4_K, Q5_K, Q6_K)
+- **Better expert handling**: Improved performance for MoE models on AMD
+- **Models affected**: All models using quantized weights on RDNA3/RDNA4 hardware
+
+---
+
+## Additional Lower-Priority Opportunities
+
+### A. rocwmma Flash Attention for CDNA
+
+In [`fattn-wmma-f16.cuh:9-23`](ggml/src/ggml-cuda/fattn-wmma-f16.cuh:9):
+
+```cpp
+#if defined(GGML_HIP_ROCWMMA_FATTN)
+#if defined(CDNA) && (ROCWMMA_VERSION_MAJOR < 2 || ROCWMMA_VERSION_MINOR > 0 || ROCWMMA_VERSION_PATCH > 0)
+#warning "rocwmma fattn on CDNA is broken on rocwmma v2.0.0, expect degraded performance"
+```
+
+**Issue**: rocwmma flash attention is broken on CDNA with rocwmma v2.0.0. Users must either:
+- Build with `GGML_HIP_ROCWMMA_FATTN=OFF` (falls back to MFMA/TILE kernels)
+- Wait for rocwmma v2.1.0+ fix
+
+**Recommendation**: Document this limitation clearly and provide build-time detection.
+
+### B. HIP Graph Support
+
+In [`common.cuh:1165`](ggml/src/ggml-cuda/common.cuh:1165):
+
+```cpp
+#if (defined(GGML_CUDA_USE_GRAPHS) || defined(GGML_HIP_GRAPHS)) || defined(GGML_MUSA_GRAPHS)
+#define USE_CUDA_GRAPH
+```
+
+**Issue**: HIP graphs are available since ROCm 5.0+ but are opt-in via `GGML_HIP_GRAPHS`.
+
+**Recommendation**: Enable HIP graphs by default for RDNA3/CDNA3 hardware to reduce CPU overhead in the inference loop.
+
+### C. Shared Memory Optimization for CDNA
+
+In [`common.cuh:340`](ggml/src/ggml-cuda/common.cuh:340):
+
+```cpp
+#if defined(GGML_USE_HIP) && (defined(__GFX9__) || defined(__GFX8__))
+    return 64;  // Physical warp size for AMD
+```
+
+**Issue**: CDNA architectures have different shared memory characteristics than CUDA GPUs. Some kernels could benefit from warp-size-specific tuning.
+
+**Recommendation**: Add CDNA-specific shared memory configuration for kernels that use dynamic shared memory.
+
+---
+
+## Priority Summary
+
+| Priority | Opportunity | Impact Area | Effort | Speed Gain |
+|----------|-------------|-------------|--------|------------|
+| P0 | Flash Attention Quantized KV | Prefill speed | Medium | 20-40% |
+| P1 | rocprim for SSM-Scan | SSM models | Low | 30-50% |
+| P1 | DKQ640 Tile Kernel | head_dim=640 models | Low | Enable |
+| P2 | Multi-GPU Copy Optimization | Multi-GPU | Medium | 2-5x |
+| P2 | MMQ Kernel Selection | Decode speed | Low | 10-25% |
+| P3 | rocwmma Workaround | Stability | Low | N/A |
+| P3 | HIP Graphs | CPU overhead | Low | 5-10% |
+
+---
+
+## Build Configuration Recommendations
+
+Add the following CMake options for ROCm-specific tuning:
+
+```cmake
+# Enable rocprim for SSM-scan operations
+option(GGML_HIP_USE_ROCPRIM "Use rocprim instead of custom SSM-scan fallback" ON)
+
+# Enable HIP graphs for reduced CPU overhead
+option(GGML_HIP_GRAPHS "Enable CUDA graphs for HIP (ROCm 5.0+)" ON)
+
+# Enable DKQ640 tile kernel for modern AMD GPUs
+option(GGML_HIP_FATTN_DKQ640 "Enable flash attention tile kernel for head_dim=640" ON)
+
+# Enable rocwmma flash attention (experimental)
+option(GGML_HIP_ROCWMMA_FATTN "Enable rocwmma flash attention" OFF)
+
+# MMQ kernel selection strategy
+# GGML_HIP_MMQ_BENCH=1: Enable runtime benchmarking
+```
+
+---
+
+## Testing Recommendations
+
+For each improvement, test on:
+
+1. **CDNA architectures**: MI100 (CDNA1), MI250X (CDNA2), MI300X (CDNA3)
+2. **RDNA architectures**: RX 6600 (RDNA2), RX 7900 XTX (RDNA3), RX 9070 (RDNA4)
+3. **Key benchmarks**:
+   - `./bench -m <model> -n 512 -b 1 -t <threads>` - Token generation speed
+   - `./bench -m <model> -n 1 -b 1 -t 1 -f 2048` - Prefill speed
+   - Multi-GPU: `./main -m <model> -ngl 2` - Cross-device copies
+
+4. **VRAM monitoring**: Track peak VRAM usage with quantized KV cache

--- a/plans/vram-allocation-fix.md
+++ b/plans/vram-allocation-fix.md
@@ -1,0 +1,94 @@
+  Task: Fix weight paging to prevent initial VRAM allocation in llama.cpp
+                                                                                                                                             
+  Context:        
+  This is a fork of llama.cpp with a custom weight paging system that pages model weights from NVMe directly to VRAM on demand via SAM/BAR1. 
+  The pager is implemented across these files:                                                                                               
+  - src/llama-weight-pager.h — struct definitions
+  - src/llama-weight-pager.cpp — implementation                                                                                              
+  - src/llama.cpp — init_weight_pager() called at model load
+  - src/llama-context.cpp — ggml_backend_sched_set_eval_callback registered at line ~1206                                                    
+  - src/llama-model.cpp — model tensor allocation                                                                                            
+                                                                                                                                             
+  The Problem:                                                                                                                               
+  When --weight-paging is used with a model larger than VRAM, startup fails with:                                                            
+  ggml_backend_cuda_buffer_type_alloc_buffer: allocating 79252.12 MiB on device 0: cudaMalloc failed: out of memory                          
+  alloc_tensor_range: failed to allocate ROCm0 buffer of size 83101871104                                          
+  The eval callback intercepts at inference time, but llama.cpp tries to allocate ALL model weights into VRAM at load time — before inference
+   ever starts.                                                                                                                              
+                                                                                                                                             
+  The Fix (3 parts):                                                                                                                         
+                                                                                                                                             
+  Part 1 — Prevent initial VRAM allocation (src/llama-model.cpp)
+                                                                                                                                             
+  In llama_model::load_tensors(), find the section that handles the non-mmap allocation path (around line 7990). It already has this logic:  
+  if (ml.no_alloc) {
+      buf = ggml_backend_buft_alloc_buffer(buft, /*size =*/ 0); // dummy buffer                                                              
+      for (ggml_tensor * t = ggml_get_first_tensor(ctx); ...) {                
+          t->buffer = buf; // set dummy buffer                 
+      }                                                                                                                                      
+  } else {
+      buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx, buft); // real buffer                                                              
+  }                                                                            
+                                                                                                                                             
+  When weight_paging_enabled is true AND the buffer type is a GPU/ROCm buffer AND we're NOT doing a dry-run (i.e., params.no_alloc is false),
+   force ml.no_alloc = true for this specific context allocation. Weight tensors will get a zero-size dummy buffer — no actual VRAM          
+  allocated.      
+                                                                                                                                             
+  The cleanest approach: before the context loop that allocates buffers, check:                                                              
+  const bool weight_paging_no_alloc = params.weight_paging_enabled;
+  Then in the allocation branch, use weight_paging_no_alloc instead of ml.no_alloc when deciding whether to do a dummy allocation for GPU    
+  buffer types. Non-GPU buffers (CPU, host) should still allocate normally.                                                                  
+                                                                                                                                             
+  After this change, at if (ml.no_alloc) { return true; } (line ~8048), we must NOT return early when weight paging is enabled — we still    
+  need to initialize the weight pager. So change that early return to:                                                                       
+  if (ml.no_alloc && !params.weight_paging_enabled) {
+      return true;                                                                                                                           
+  }               
+  And skip load_all_data when weight paging is enabled (we don't read data at load time):
+  if (!params.weight_paging_enabled) {
+      for (auto & [ctx, buf_map] : ctx_buf_maps) {                                                                                           
+          if (!ml.load_all_data(...)) { return false; }
+      }                                                                                                                                      
+  }               
+                                                                                                                                             
+  Part 2 — Set tensor->data in the eval callback (src/llama-weight-pager.cpp)
+                                                                                                                                             
+  Currently weight_pager_eval_cb calls pager->ensure(name) to get a VRAM pointer but doesn't set tensor->data. After a no_alloc load,        
+  tensor->data is nullptr. The kernel will segfault.                                                                                         
+                                                                                                                                             
+  Fix the ask=false branch of weight_pager_eval_cb to also set tensor->data:                                                                 
+  // In the ask=false branch, after calling ensure():
+  void * vram_ptr = pager->ensure(ggml_get_name(t));                                                                                         
+  if (vram_ptr) {                                                                                                                            
+      t->data = vram_ptr;                                                                                                                    
+  }                                                                                                                                          
+                                                                                                                                             
+  This redirects the tensor's data pointer to the live VRAM slot just before the kernel executes.
+                                                                                                                                             
+  Part 3 — Handle the case where tensor->data must stay valid (src/llama-weight-pager.cpp)
+                                                                                                                                             
+  The eval callback fires per-node. After a slot is evicted (LRU), the tensor->data pointer for the evicted tensor becomes stale — it points 
+  to a slot that now contains different data. This is actually fine because:
+  - We set tensor->data fresh each time the tensor is about to execute                                                                       
+  - The pager's ensure() either returns the existing valid slot (if still resident) or pages it back in                                      
+                                                                                                       
+  No extra work needed here — the existing ensure() logic handles this correctly as long as we always set tensor->data before kernel         
+  execution.                                                                                                                                 
+                                                                                                                                             
+  What NOT to change:                                                                                                                        
+  - fit.cpp already has use_direct_io = false — don't touch
+  - llama-context.cpp eval callback registration is correct — don't touch                                                                    
+  - init_weight_pager() in llama.cpp is correct — don't touch            
+  - The llama_weight_pager::ensure() / page_in() / evict_lru() logic is correct — don't touch                                                
+                                                                                                                                             
+  Key invariant to preserve:                                                                                                                 
+  The dummy buffer set on weight tensors (t->buffer = dummy_buf) must be a valid ROCm buffer type (zero-size, but correct type). This tells  
+  the ggml scheduler to run weight-consuming ops on the GPU backend. Do NOT change weight tensors to CPU buffer type — that would cause GPU  
+  kernels to be skipped.
+                                                                                                                                             
+  Success criteria:
+  Server starts, logs show weight pager initializing with N pages, model loads without OOM, and during inference the eval callback fires and
+  pages tensors in/out of the VRAM slot pool.                                                                                                
+  
+  ---                                                                                                                                        
+  That gives Qwen the full picture — the exact files, the existing hook points, the three discrete changes, and the invariants to preserve.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(llama
             llama-io-uring.cpp
             llama-model-saver.cpp
             llama-model.cpp
+            llama-weight-pager.cpp
             llama-quant.cpp
             llama-sampler.cpp
             llama-vocab.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(llama
             llama-io.cpp
             llama-kv-cache.cpp
             llama-kv-cache-iswa.cpp
+            llama-kv-cache-tiered.cpp
             llama-memory.cpp
             llama-memory-hybrid.cpp
             llama-memory-hybrid-iswa.cpp
@@ -50,6 +51,10 @@ set_target_properties(llama PROPERTIES
 
 target_include_directories(llama PRIVATE .)
 target_include_directories(llama PUBLIC ../include)
+if(GGML_HIP)
+    target_include_directories(llama PRIVATE /opt/rocm/include)
+    target_compile_definitions(llama PRIVATE __HIP_PLATFORM_AMD__)
+endif()
 target_compile_features   (llama PRIVATE cxx_std_17) # don't bump
 
 target_link_libraries(llama PUBLIC ggml)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(llama
             llama-memory-recurrent.cpp
             llama-mmap.cpp
             llama-model-loader.cpp
+            llama-io-uring.cpp
             llama-model-saver.cpp
             llama-model.cpp
             llama-quant.cpp
@@ -52,6 +53,17 @@ target_include_directories(llama PUBLIC ../include)
 target_compile_features   (llama PRIVATE cxx_std_17) # don't bump
 
 target_link_libraries(llama PUBLIC ggml)
+
+if (UNIX AND NOT APPLE)
+    find_library(LIBURING_LIBRARY NAMES uring)
+    if (LIBURING_LIBRARY)
+        target_compile_definitions(llama PRIVATE LLAMA_HAVE_IO_URING)
+        target_link_libraries(llama PRIVATE ${LIBURING_LIBRARY})
+        message(STATUS "Found liburing: ${LIBURING_LIBRARY} — io_uring model loader enabled")
+    else()
+        message(STATUS "liburing not found — io_uring model loader disabled")
+    endif()
+endif()
 
 if (BUILD_SHARED_LIBS)
     set_target_properties(llama PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -8,6 +8,7 @@
 #include "llama-memory.h"
 #include "llama-mmap.h"
 #include "llama-model.h"
+#include "llama-weight-pager.h"
 #include "llama-ext.h"
 #include "llama.h"
 
@@ -1197,7 +1198,15 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         res->reset();
 
         ggml_backend_sched_reset(sched.get());
-        ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
+        
+        // Use weight pager callback if model has weight_pager enabled
+        if (model.weight_pager) {
+            // The weight pager callback handles paging weights from NVMe to VRAM
+            // It takes precedence over the user-provided callback for weight tensors
+            ggml_backend_sched_set_eval_callback(sched.get(), weight_pager_eval_cb, model.weight_pager.get());
+        } else {
+            ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
+        }
 
         //const auto t_start_us = ggml_time_us();
 
@@ -1211,11 +1220,13 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
             return nullptr;
         }
 
+        LLAMA_LOG_INFO("%s: calling ggml_backend_sched_alloc_graph\n", __func__);
         if (!ggml_backend_sched_alloc_graph(sched.get(), gf)) {
-            LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
+            LLAMA_LOG_ERROR("%s: ggml_backend_sched_alloc_graph returned false\n", __func__);
             ret = GGML_STATUS_ALLOC_FAILED;
             return nullptr;
         }
+        LLAMA_LOG_INFO("%s: ggml_backend_sched_alloc_graph succeeded\n", __func__);
     }
 
     // set the input data for the input tensors
@@ -2188,10 +2199,12 @@ ggml_status llama_context::graph_compute(
         set_n_threads_fn.second(set_n_threads_fn.first, n_threads);
     }
 
+    LLAMA_LOG_INFO("%s: calling ggml_backend_sched_graph_compute_async\n", __func__);
     auto status = ggml_backend_sched_graph_compute_async(sched.get(), gf);
     if (status != GGML_STATUS_SUCCESS) {
         LLAMA_LOG_ERROR("%s: ggml_backend_sched_graph_compute_async failed with error %d\n", __func__, status);
     }
+    LLAMA_LOG_INFO("%s: ggml_backend_sched_graph_compute_async returned status=%d\n", __func__, status);
 
     // fprintf(stderr, "splits: %d\n", ggml_backend_sched_get_n_splits(sched));
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -13,6 +13,7 @@
 #include "llama.h"
 
 #include <cinttypes>
+#include <cstdlib>
 #include <cmath>
 #include <cstring>
 #include <limits>
@@ -1201,8 +1202,9 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         
         // Use weight pager callback if model has weight_pager enabled
         if (model.weight_pager) {
-            // The weight pager callback handles paging weights from NVMe to VRAM
-            // It takes precedence over the user-provided callback for weight tensors
+            // hipGraph bakes tensor->data pointers at capture time; our eval callback
+            // changes tensor->data dynamically, so graphs must be disabled.
+            setenv("GGML_CUDA_DISABLE_GRAPHS", "1", 1);
             ggml_backend_sched_set_eval_callback(sched.get(), weight_pager_eval_cb, model.weight_pager.get());
         } else {
             ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);

--- a/src/llama-eviction-policy.h
+++ b/src/llama-eviction-policy.h
@@ -1,0 +1,235 @@
+#pragma once
+
+#include "llama.h"
+#include <chrono>
+#include <vector>
+#include <unordered_map>
+#include <ctime>
+#include <algorithm>
+
+// Eviction policy types
+enum llama_eviction_policy {
+    LRU,           // Least Recently Used
+    LFU,           // Least Frequently Used
+    ATTENTION,     // Attention-based eviction
+    HYBRID         // Attention + recency + frequency (default)
+};
+
+// Eviction score components
+struct llama_eviction_score {
+    float attention_weight;    // 0.0-1.0, lower = less important
+    float recency_weight;      // Based on time since last access
+    float frequency_weight;    // Based on access frequency
+
+    // Default weights for hybrid policy
+    static constexpr float DEFAULT_ATTENTION_WEIGHT = 0.5f;
+    static constexpr float DEFAULT_RECENCY_WEIGHT = 0.3f;
+    static constexpr float DEFAULT_FREQUENCY_WEIGHT = 0.2f;
+
+    // Configurable weights for hybrid policy
+    float att_w = DEFAULT_ATTENTION_WEIGHT;
+    float rec_w = DEFAULT_RECENCY_WEIGHT;
+    float freq_w = DEFAULT_FREQUENCY_WEIGHT;
+
+    // Calculate combined eviction score (higher = more likely to evict)
+    float calculate() const {
+        return att_w * attention_weight +
+               rec_w * recency_weight +
+               freq_w * frequency_weight;
+    }
+
+    // Calculate with custom weights
+    float calculate(float att_w, float rec_w, float freq_w) const {
+        return att_w * attention_weight +
+               rec_w * recency_weight +
+               freq_w * frequency_weight;
+    }
+};
+
+// Token metadata for eviction decisions
+struct llama_token_metadata {
+    llama_pos position;
+    float attention_score;
+    std::time_t last_access;
+    uint32_t access_count;
+
+    llama_token_metadata() : position(0), attention_score(0.0f),
+                             last_access(std::time(nullptr)), access_count(0) {}
+
+    llama_token_metadata(llama_pos pos, float att_score = 0.0f)
+        : position(pos), attention_score(att_score),
+          last_access(std::time(nullptr)), access_count(0) {}
+
+    void record_access() {
+        access_count++;
+        last_access = std::time(nullptr);
+    }
+
+    void update_attention_score(float score) {
+        // Exponential moving average for attention score
+        attention_score = 0.7f * attention_score + 0.3f * score;
+    }
+};
+
+// Token metadata store for eviction tracking
+class llama_token_metadata_store {
+public:
+    using pos_to_metadata = std::unordered_map<llama_pos, llama_token_metadata>;
+
+    void record_access(llama_pos pos) {
+        auto it = metadata.find(pos);
+        if (it != metadata.end()) {
+            it->second.record_access();
+        } else {
+            metadata.emplace(pos, llama_token_metadata(pos));
+        }
+    }
+
+    void update_attention(llama_pos pos, float attention_score) {
+        auto it = metadata.find(pos);
+        if (it != metadata.end()) {
+            it->second.update_attention_score(attention_score);
+        }
+    }
+
+    void add_token(llama_pos pos, float initial_attention = 0.0f) {
+        if (metadata.find(pos) == metadata.end()) {
+            metadata.emplace(pos, llama_token_metadata(pos, initial_attention));
+        }
+    }
+
+    void remove_token(llama_pos pos) {
+        metadata.erase(pos);
+    }
+
+    const llama_token_metadata* get_metadata(llama_pos pos) const {
+        auto it = metadata.find(pos);
+        return it != metadata.end() ? &it->second : nullptr;
+    }
+
+    // Batch attention update for efficiency
+    void batch_update_attention(const std::vector<llama_pos>& positions,
+                                 const std::vector<float>& attention_scores) {
+        if (positions.size() != attention_scores.size()) {
+            return;
+        }
+        for (size_t i = 0; i < positions.size(); i++) {
+            update_attention(positions[i], attention_scores[i]);
+        }
+    }
+
+    // Get tokens below attention threshold (candidates for eviction)
+    std::vector<llama_pos> get_low_attention_tokens(float threshold) const {
+        std::vector<llama_pos> result;
+        for (const auto& kv : metadata) {
+            if (kv.second.attention_score < threshold) {
+                result.push_back(kv.first);
+            }
+        }
+        return result;
+    }
+
+    // Normalize attention scores across all tokens
+    void normalize_attention_scores() {
+        if (metadata.empty()) return;
+
+        // Find max attention score
+        float max_score = 0.0f;
+        for (const auto& kv : metadata) {
+            max_score = std::max(max_score, kv.second.attention_score);
+        }
+
+        if (max_score > 0.0f) {
+            for (auto& kv : metadata) {
+                kv.second.attention_score /= max_score;
+            }
+        }
+    }
+
+    // Clear all metadata
+    void clear_all() {
+        metadata.clear();
+    }
+
+    // Get number of tracked tokens
+    size_t get_token_count() const {
+        return metadata.size();
+    }
+
+    // Get tokens sorted by eviction score (highest first)
+    std::vector<llama_pos> get_eviction_candidates(
+        llama_eviction_policy policy,
+        uint32_t count,
+        float attention_weight = llama_eviction_score::DEFAULT_ATTENTION_WEIGHT,
+        float recency_weight = llama_eviction_score::DEFAULT_RECENCY_WEIGHT,
+        float frequency_weight = llama_eviction_score::DEFAULT_FREQUENCY_WEIGHT) const {
+
+        std::vector<std::pair<llama_pos, float>> scored_tokens;
+        scored_tokens.reserve(metadata.size());
+
+        const auto now = std::time(nullptr);
+
+        for (const auto& kv : metadata) {
+            const auto& pos = kv.first;
+            const auto& meta = kv.second;
+            float score = 0.0f;
+
+            switch (policy) {
+                case LRU:
+                    // Score based on recency (older = higher score)
+                    score = float(now - meta.last_access);
+                    break;
+
+                case LFU:
+                    // Score based on frequency (less frequent = higher score)
+                    score = meta.access_count > 0 ? 1.0f / float(meta.access_count) : 1.0f;
+                    break;
+
+                case ATTENTION:
+                    // Score based on attention (lower attention = higher score)
+                    score = 1.0f - meta.attention_score;
+                    break;
+
+                case HYBRID:
+                default:
+                    // Combined score
+                    float att_score = 1.0f - meta.attention_score;
+                    float rec_score = float(now - meta.last_access) / 60.0f; // Normalize to minutes
+                    float freq_score = meta.access_count > 0 ? 1.0f / float(meta.access_count) : 1.0f;
+                    score = att_score * attention_weight +
+                            rec_score * recency_weight +
+                            freq_score * frequency_weight;
+                    break;
+            }
+
+            scored_tokens.emplace_back(pos, score);
+        }
+
+        // Sort by score (highest first)
+        std::sort(scored_tokens.begin(), scored_tokens.end(),
+            [](const auto& a, const auto& b) { return a.second > b.second; });
+
+        // Return top 'count' positions
+        std::vector<llama_pos> result;
+        size_t n = std::min(count, uint32_t(scored_tokens.size()));
+        result.reserve(n);
+        for (size_t i = 0; i < n; ++i) {
+            result.push_back(scored_tokens[i].first);
+        }
+
+        return result;
+    }
+
+    size_t size() const { return metadata.size(); }
+    void clear() { metadata.clear(); }
+
+private:
+    pos_to_metadata metadata;
+};
+
+// Layer importance for per-layer eviction decisions
+struct llama_layer_importance {
+    float importance;  // 0.0-1.0, higher = more important to keep
+
+    static constexpr float DEFAULT_IMPORTANCE = 1.0f;
+};

--- a/src/llama-io-uring.cpp
+++ b/src/llama-io-uring.cpp
@@ -1,0 +1,77 @@
+#ifdef LLAMA_HAVE_IO_URING
+
+#include "llama-io-uring.h"
+#include "llama-impl.h"  // LLAMA_LOG_*
+
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+
+llama_io_uring::llama_io_uring(int fd, int queue_depth) : fd_(fd) {
+    if (fd < 0) return;
+    int ret = io_uring_queue_init(queue_depth, &ring_, 0);
+    if (ret < 0) {
+        LLAMA_LOG_WARN("%s: io_uring_queue_init failed: %s — falling back to pread\n",
+                       __func__, strerror(-ret));
+        return;
+    }
+    ring_ok_ = true;
+}
+
+llama_io_uring::~llama_io_uring() {
+    if (!ring_ok_) return;
+    if (bufs_registered_) io_uring_unregister_buffers(&ring_);
+    io_uring_queue_exit(&ring_);
+}
+
+bool llama_io_uring::register_buffers(struct iovec * bufs, int n_bufs) {
+    if (!ring_ok_) return false;
+    int ret = io_uring_register_buffers(&ring_, bufs, n_bufs);
+    if (ret < 0) {
+        LLAMA_LOG_WARN("%s: io_uring_register_buffers failed: %s\n",
+                       __func__, strerror(-ret));
+        return false;
+    }
+    bufs_registered_ = true;
+    return true;
+}
+
+void llama_io_uring::submit_read(int buf_idx, void * buf, size_t size,
+                                  uint64_t offset, uint64_t user_data) {
+    struct io_uring_sqe * sqe = io_uring_get_sqe(&ring_);
+    if (!sqe) {
+        // Ring full — flush and retry
+        io_uring_submit(&ring_);
+        sqe = io_uring_get_sqe(&ring_);
+        if (!sqe) return;
+    }
+
+    if (bufs_registered_) {
+        io_uring_prep_read_fixed(sqe, fd_, buf, (unsigned)size,
+                                 (off_t)offset, buf_idx);
+    } else {
+        io_uring_prep_read(sqe, fd_, buf, (unsigned)size, (off_t)offset);
+    }
+    sqe->user_data = user_data;
+    pending_++;
+}
+
+void llama_io_uring::submit() {
+    if (pending_ > 0) io_uring_submit(&ring_);
+}
+
+uint64_t llama_io_uring::wait_one(int * bytes_read) {
+    struct io_uring_cqe * cqe = nullptr;
+    int ret = io_uring_wait_cqe(&ring_, &cqe);
+    if (ret < 0 || !cqe) {
+        if (bytes_read) *bytes_read = ret;
+        return UINT64_MAX;
+    }
+    uint64_t ud = cqe->user_data;
+    if (bytes_read) *bytes_read = cqe->res;
+    io_uring_cqe_seen(&ring_, cqe);
+    pending_--;
+    return ud;
+}
+
+#endif // LLAMA_HAVE_IO_URING

--- a/src/llama-io-uring.h
+++ b/src/llama-io-uring.h
@@ -1,0 +1,54 @@
+#pragma once
+// io_uring-backed async NVMe reader for model weight loading.
+// Drop-in replacement for the synchronous read_raw_unsafe path in
+// llama_model_loader::load_all_data.  Overlaps NVMe reads with GPU DMA
+// uploads to approach the SN850X sequential ceiling (~5.7 GB/s on RDNA4
+// via SAM-mapped PCIe BAR).
+//
+// Only compiled on Linux when liburing is present (LLAMA_HAVE_IO_URING).
+
+#ifdef LLAMA_HAVE_IO_URING
+
+#include <cstddef>
+#include <cstdint>
+#include <liburing.h>
+
+// Wraps a single io_uring instance tied to one file descriptor.
+// Caller owns the staging buffers; this class only manages submissions
+// and completions.
+class llama_io_uring {
+public:
+    explicit llama_io_uring(int fd, int queue_depth = 64);
+    ~llama_io_uring();
+
+    llama_io_uring(const llama_io_uring &) = delete;
+    llama_io_uring & operator=(const llama_io_uring &) = delete;
+
+    // Register fixed buffers for zero-copy DMA into pinned host memory.
+    // bufs / n_bufs must stay alive for the lifetime of this object.
+    bool register_buffers(struct iovec * bufs, int n_bufs);
+
+    // Submit a fixed-buffer read (buf_idx indexes into registered buffers).
+    // offset is the absolute byte offset in the file.
+    // user_data is returned verbatim in wait_one().
+    void submit_read(int buf_idx, void * buf, size_t size, uint64_t offset,
+                     uint64_t user_data);
+
+    // Flush pending submissions to the kernel.
+    void submit();
+
+    // Wait for one completion.  Returns user_data; *bytes_read is set to the
+    // result (negative = error code from -errno).
+    uint64_t wait_one(int * bytes_read);
+
+    bool valid() const { return ring_ok_; }
+
+private:
+    int       fd_;
+    bool      ring_ok_ = false;
+    bool      bufs_registered_ = false;
+    int       pending_ = 0;
+    struct io_uring ring_;
+};
+
+#endif // LLAMA_HAVE_IO_URING

--- a/src/llama-kv-cache-tiered.cpp
+++ b/src/llama-kv-cache-tiered.cpp
@@ -336,6 +336,10 @@ bool llama_kv_cache_tiered::init() {
         LLAMA_LOG_INFO("%s: warm tier: %u slots reserved (buffers wired after KV layers available)\n",
                        __func__, config.warm_capacity());
     }
+    if (config.cold_capacity() > 0) {
+        LLAMA_LOG_INFO("%s: cold tier: %u slots reserved (SSD path: %s)\n",
+                       __func__, config.cold_capacity(), ssd_path.c_str());
+    }
 
     return true;
 }
@@ -651,8 +655,12 @@ void llama_kv_cache_tiered::set_kv_layers_from_cache(llama_kv_cache * cache) {
         tl.v      = cache->get_layer_v_raw(il);
         tl.v_trans = vtrans;
         tl.kv_size = kvsz;
-        if (tl.k) tl.k_bytes = (size_t)tl.k->ne[0] * ggml_element_size(tl.k);
-        if (tl.v) tl.v_bytes = (size_t)tl.v->ne[0] * ggml_element_size(tl.v);
+        // Use nb[1] (the actual row stride) for per-token byte size so that
+        // block-quantized types (turbo4, Q4_K, etc.) are sized correctly.
+        // ggml_element_size returns the block size, not bytes-per-element, so
+        // ne[0]*element_size is wildly wrong for quantized caches.
+        if (tl.k) tl.k_bytes = tl.k->nb[1];
+        if (tl.v) tl.v_bytes = tl.v->nb[1];
     }
 
     // (Re)allocate per-layer warm buffers using already-reserved slot count
@@ -666,8 +674,18 @@ void llama_kv_cache_tiered::set_kv_layers_from_cache(llama_kv_cache * cache) {
         delete[] tl.warm_k;
         delete[] tl.warm_v;
         tl.warm_k = tl.warm_v = nullptr;
+        // Skip RAM staging buffers when a GPU warm device is configured — the
+        // GPU VRAM path (warm_k_dev/warm_v_dev) is used instead, so allocating
+        // n_warm * kv_bytes of RAM here would just trigger OOM for large contexts.
+#ifndef GGML_USE_HIP
         if (n_warm > 0 && tl.k_bytes > 0) tl.warm_k = new uint8_t[n_warm * tl.k_bytes]();
         if (n_warm > 0 && tl.v_bytes > 0) tl.warm_v = new uint8_t[n_warm * tl.v_bytes]();
+#else
+        if (config.warm_device < 0) {
+            if (n_warm > 0 && tl.k_bytes > 0) tl.warm_k = new uint8_t[n_warm * tl.k_bytes]();
+            if (n_warm > 0 && tl.v_bytes > 0) tl.warm_v = new uint8_t[n_warm * tl.v_bytes]();
+        }
+#endif
 
 #ifdef GGML_USE_HIP
         if (config.warm_device >= 0 && n_warm > 0) {
@@ -686,8 +704,24 @@ void llama_kv_cache_tiered::set_kv_layers_from_cache(llama_kv_cache * cache) {
         total_mb += (tl.k_bytes + tl.v_bytes) * n_warm;
     total_mb /= (1024*1024);
 
-    LLAMA_LOG_INFO("%s: wired %u KV layers (v_trans=%d, kv_size=%lld), warm RAM: ~%zu MB (%u slots x %u layers)\n",
+#ifdef GGML_USE_HIP
+    if (config.warm_device >= 0) {
+        LLAMA_LOG_INFO("%s: wired %u KV layers (v_trans=%d, kv_size=%lld), warm GPU: ~%zu MiB (%u slots x %u layers)\n",
+                       __func__, n, (int)vtrans, (long long)kvsz, total_mb, n_warm, n);
+    } else {
+        LLAMA_LOG_INFO("%s: wired %u KV layers (v_trans=%d, kv_size=%lld), warm RAM: ~%zu MiB (%u slots x %u layers)\n",
+                       __func__, n, (int)vtrans, (long long)kvsz, total_mb, n_warm, n);
+    }
+#else
+    LLAMA_LOG_INFO("%s: wired %u KV layers (v_trans=%d, kv_size=%lld), warm RAM: ~%zu MiB (%u slots x %u layers)\n",
                    __func__, n, (int)vtrans, (long long)kvsz, total_mb, n_warm, n);
+#endif
+#ifdef GGML_USE_HIP
+    if (config.warm_device >= 0 && n_warm > 0 && !kv_layers.empty() && kv_layers[0].warm_k_dev) {
+        LLAMA_LOG_INFO("llama_kv_cache_tiered:      ROCm%d KV warm buffer size = %6.2f MiB (%u slots x %u layers)\n",
+                       config.warm_device, (float)total_mb, n_warm, n);
+    }
+#endif
 }
 
 bool llama_kv_cache_tiered::migrate_tokens(const std::vector<llama_pos>& positions,

--- a/src/llama-kv-cache-tiered.cpp
+++ b/src/llama-kv-cache-tiered.cpp
@@ -1,0 +1,640 @@
+#include "llama-kv-cache-tiered.h"
+
+#include "llama-impl.h"
+#include "llama-io.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <chrono>
+#include <filesystem>
+#include <cmath>
+#include <limits>
+
+#ifdef GGML_USE_HIP
+#include <hip/hip_runtime.h>
+#endif
+
+//
+// llama_ssd_storage_format
+//
+
+// Quantize float32 to int4 (4-bit)
+std::vector<uint8_t> llama_ssd_storage_format::quantize_int4(const float* data, uint32_t n_elements) {
+    std::vector<uint8_t> result((n_elements + 1) / 2);  // 2 values per byte
+
+    for (uint32_t i = 0; i < n_elements; i += 2) {
+        // Quantize to 4-bit range [-8, 7]
+        int32_t v0 = std::max(-8, std::min(7, int(std::round(data[i] * 15.0f))));
+        int32_t v1 = std::max(-8, std::min(7, int(std::round(data[i + 1] * 15.0f))));
+
+        // Pack into single byte
+        result[i / 2] = uint8_t((v0 & 0x0F) | ((v1 & 0x0F) << 4));
+    }
+
+    return result;
+}
+
+// Quantize float32 to int8 (8-bit)
+std::vector<uint8_t> llama_ssd_storage_format::quantize_int8(const float* data, uint32_t n_elements) {
+    std::vector<uint8_t> result(n_elements);
+
+    for (uint32_t i = 0; i < n_elements; i++) {
+        // Quantize to int8 range [-128, 127]
+        result[i] = uint8_t(std::max(-128, std::min(127, int(std::round(data[i] * 127.0f)))) + 128);
+    }
+
+    return result;
+}
+
+// Dequantize int4 to float32
+bool llama_ssd_storage_format::dequantize_int4(const uint8_t* data, float* out, uint32_t n_elements) {
+    for (uint32_t i = 0; i < (n_elements + 1) / 2; i++) {
+        uint8_t byte = data[i];
+        int32_t v0 = (byte & 0x0F) - 8;  // Lower 4 bits
+        int32_t v1 = ((byte >> 4) & 0x0F) - 8;  // Upper 4 bits
+
+        out[2 * i] = float(v0) / 15.0f;
+        if (2 * i + 1 < n_elements) {
+            out[2 * i + 1] = float(v1) / 15.0f;
+        }
+    }
+
+    return true;
+}
+
+// Dequantize int8 to float32
+bool llama_ssd_storage_format::dequantize_int8(const uint8_t* data, float* out, uint32_t n_elements) {
+    for (uint32_t i = 0; i < n_elements; i++) {
+        out[i] = float(data[i] - 128) / 127.0f;
+    }
+
+    return true;
+}
+
+bool llama_ssd_storage_format::write(const std::string& path,
+                                       const float* k_data,
+                                       const float* v_data,
+                                       uint32_t n_tokens,
+                                       uint32_t n_layers,
+                                       uint32_t n_embd_k,
+                                       uint32_t n_embd_v,
+                                       llama_cache_compression compression) {
+    std::ofstream file(path, std::ofstream::binary);
+    if (!file) {
+        return false;
+    }
+
+    // Calculate data size based on compression
+    size_t element_size = sizeof(float);
+    if (compression == COMPRESSION_INT4) {
+        element_size = sizeof(uint8_t) / 2;  // 4-bit = 0.5 bytes per element
+    } else if (compression == COMPRESSION_INT8) {
+        element_size = sizeof(uint8_t);  // 8-bit = 1 byte per element
+    }
+
+    size_t total_elements = n_tokens * n_layers * (n_embd_k + n_embd_v);
+    size_t compressed_size = total_elements * element_size;
+
+    // Write header
+    file_header header;
+    header.magic = MAGIC;
+    header.version = VERSION;
+    header.n_layers = n_layers;
+    header.n_embd_k = n_embd_k;
+    header.n_embd_v = n_embd_v;
+    header.n_tokens = n_tokens;
+    header.compression_type = uint32_t(compression);
+    header.layer_offset = 0;
+    header.attention_threshold = 0.0f;
+    header.index_offset = 0;  // Will be filled later
+    header.index_size = 0;    // Will be filled later
+
+    file.write(reinterpret_cast<char*>(&header), sizeof(file_header));
+
+    // Write data with compression
+    if (compression == COMPRESSION_INT4) {
+        // Quantize and write K data
+        auto k_quant = quantize_int4(k_data, n_tokens * n_layers * n_embd_k);
+        uint32_t k_size = uint32_t(k_quant.size());
+        file.write(reinterpret_cast<char*>(&k_size), sizeof(uint32_t));
+        file.write(reinterpret_cast<char*>(k_quant.data()), k_quant.size());
+
+        // Quantize and write V data
+        auto v_quant = quantize_int4(v_data, n_tokens * n_layers * n_embd_v);
+        uint32_t v_size = uint32_t(v_quant.size());
+        file.write(reinterpret_cast<char*>(&v_size), sizeof(uint32_t));
+        file.write(reinterpret_cast<char*>(v_quant.data()), v_quant.size());
+    } else if (compression == COMPRESSION_INT8) {
+        // Quantize and write K data
+        auto k_quant = quantize_int8(k_data, n_tokens * n_layers * n_embd_k);
+        uint32_t k_size = uint32_t(k_quant.size());
+        file.write(reinterpret_cast<char*>(&k_size), sizeof(uint32_t));
+        file.write(reinterpret_cast<char*>(k_quant.data()), k_quant.size());
+
+        // Quantize and write V data
+        auto v_quant = quantize_int8(v_data, n_tokens * n_layers * n_embd_v);
+        uint32_t v_size = uint32_t(v_quant.size());
+        file.write(reinterpret_cast<char*>(&v_size), sizeof(uint32_t));
+        file.write(reinterpret_cast<char*>(v_quant.data()), v_quant.size());
+    } else {
+        // No compression - write raw floats
+        size_t k_size = n_tokens * n_layers * n_embd_k * sizeof(float);
+        size_t v_size = n_tokens * n_layers * n_embd_v * sizeof(float);
+        file.write(const_cast<char*>(reinterpret_cast<const char*>(k_data)), k_size);
+        file.write(const_cast<char*>(reinterpret_cast<const char*>(v_data)), v_size);
+    }
+
+    return file.good();
+}
+
+bool llama_ssd_storage_format::read(const std::string& path,
+                                      float* k_data,
+                                      float* v_data,
+                                      uint32_t n_tokens,
+                                      uint32_t n_layers,
+                                      uint32_t n_embd_k,
+                                      uint32_t n_embd_v) {
+    std::ifstream file(path, std::ifstream::binary);
+    if (!file) {
+        return false;
+    }
+
+    // Read and validate header
+    file_header header;
+    file.read(reinterpret_cast<char*>(&header), sizeof(file_header));
+
+    if (header.magic != MAGIC || header.version != VERSION) {
+        return false;
+    }
+
+    // Read data based on compression type
+    if (header.compression_type == COMPRESSION_INT4) {
+        // Read K data
+        uint32_t k_size;
+        file.read(reinterpret_cast<char*>(&k_size), sizeof(uint32_t));
+        std::vector<uint8_t> k_quant(k_size);
+        file.read(reinterpret_cast<char*>(k_quant.data()), k_size);
+        dequantize_int4(k_quant.data(), k_data, n_tokens * n_layers * n_embd_k);
+
+        // Read V data
+        uint32_t v_size;
+        file.read(reinterpret_cast<char*>(&v_size), sizeof(uint32_t));
+        std::vector<uint8_t> v_quant(v_size);
+        file.read(reinterpret_cast<char*>(v_quant.data()), v_size);
+        dequantize_int4(v_quant.data(), v_data, n_tokens * n_layers * n_embd_v);
+    } else if (header.compression_type == COMPRESSION_INT8) {
+        // Read K data
+        uint32_t k_size;
+        file.read(reinterpret_cast<char*>(&k_size), sizeof(uint32_t));
+        std::vector<uint8_t> k_quant(k_size);
+        file.read(reinterpret_cast<char*>(k_quant.data()), k_size);
+        dequantize_int8(k_quant.data(), k_data, n_tokens * n_layers * n_embd_k);
+
+        // Read V data
+        uint32_t v_size;
+        file.read(reinterpret_cast<char*>(&v_size), sizeof(uint32_t));
+        std::vector<uint8_t> v_quant(v_size);
+        file.read(reinterpret_cast<char*>(v_quant.data()), v_size);
+        dequantize_int8(v_quant.data(), v_data, n_tokens * n_layers * n_embd_v);
+    } else {
+        // No compression - read raw floats
+        size_t k_size = n_tokens * n_layers * n_embd_k * sizeof(float);
+        size_t v_size = n_tokens * n_layers * n_embd_v * sizeof(float);
+        file.read(reinterpret_cast<char*>(k_data), k_size);
+        file.read(reinterpret_cast<char*>(v_data), v_size);
+    }
+
+    return file.good();
+}
+
+bool llama_ssd_storage_format::build_index(const std::string& index_path,
+                                            const std::string& data_path,
+                                            uint32_t n_layers) {
+    // Build layer index for fast lookup
+    std::ifstream data_file(data_path, std::ifstream::binary);
+    if (!data_file) {
+        return false;
+    }
+
+    // Read header to get file structure
+    file_header header;
+    data_file.read(reinterpret_cast<char*>(&header), sizeof(file_header));
+
+    // Build index entries for each layer
+    layer_index.clear();
+    for (uint32_t layer = 0; layer < n_layers; layer++) {
+        layer_index_entry entry;
+        entry.layer = layer;
+        entry.file_offset = sizeof(file_header) + layer * (header.n_embd_k + header.n_embd_v) * sizeof(float);
+        entry.n_tokens = header.n_tokens;
+        entry.data_size = header.n_tokens * (header.n_embd_k + header.n_embd_v) * sizeof(float);
+        layer_index.push_back(entry);
+    }
+
+    // Save index to file
+    return save_index(index_path);
+}
+
+bool llama_ssd_storage_format::load_index(const std::string& index_path) {
+    std::ifstream file(index_path, std::ifstream::binary);
+    if (!file) {
+        return false;
+    }
+
+    // Read number of entries
+    uint32_t n_entries;
+    file.read(reinterpret_cast<char*>(&n_entries), sizeof(uint32_t));
+
+    // Read each entry
+    layer_index.clear();
+    for (uint32_t i = 0; i < n_entries; i++) {
+        layer_index_entry entry;
+        file.read(reinterpret_cast<char*>(&entry), sizeof(layer_index_entry));
+        layer_index.push_back(entry);
+    }
+
+    return file.good();
+}
+
+bool llama_ssd_storage_format::save_index(const std::string& index_path) {
+    std::ofstream file(index_path, std::ofstream::binary);
+    if (!file) {
+        return false;
+    }
+
+    // Write number of entries
+    uint32_t n_entries = uint32_t(layer_index.size());
+    file.write(reinterpret_cast<char*>(&n_entries), sizeof(uint32_t));
+
+    // Write each entry
+    for (const auto& entry : layer_index) {
+        file.write(reinterpret_cast<const char*>(&entry), sizeof(layer_index_entry));
+    }
+
+    return file.good();
+}
+
+uint64_t llama_ssd_storage_format::get_layer_offset(uint32_t layer) const {
+    for (const auto& entry : layer_index) {
+        if (entry.layer == layer) {
+            return entry.file_offset;
+        }
+    }
+    return 0;  // Not found
+}
+
+bool llama_ssd_storage_format::has_layer(uint32_t layer) const {
+    for (const auto& entry : layer_index) {
+        if (entry.layer == layer) {
+            return true;
+        }
+    }
+    return false;
+}
+
+//
+// llama_kv_cache_tiered
+//
+
+llama_kv_cache_tiered::llama_kv_cache_tiered(
+    const llama_model& model,
+    const llama_tier_config& config,
+    const std::string& ssd_path,
+    llama_eviction_policy eviction_policy,
+    llama_cache_compression compression,
+    float attention_threshold)
+    : config(config),
+      eviction_policy(eviction_policy),
+      ssd_path(ssd_path),
+      compression(compression),
+      attention_threshold(attention_threshold) {
+    stats.reset();
+}
+
+llama_kv_cache_tiered::~llama_kv_cache_tiered() {
+    // Cleanup
+}
+
+bool llama_kv_cache_tiered::init() {
+    // Create SSD directory if it doesn't exist
+    std::filesystem::path ssd_dir(ssd_path);
+    if (!std::filesystem::exists(ssd_dir)) {
+        std::filesystem::create_directories(ssd_dir);
+    }
+    return true;
+}
+
+bool llama_kv_cache_tiered::resize(uint32_t new_total_ctx) {
+    std::lock_guard<std::mutex> lock(mutex);
+    config.total_ctx = new_total_ctx;
+    return true;
+}
+
+bool llama_kv_cache_tiered::set_eviction_policy(llama_eviction_policy policy) {
+    std::lock_guard<std::mutex> lock(mutex);
+    eviction_policy = policy;
+    return true;
+}
+
+bool llama_kv_cache_tiered::set_attention_threshold(float threshold) {
+    std::lock_guard<std::mutex> lock(mutex);
+    attention_threshold = threshold;
+    return true;
+}
+
+bool llama_kv_cache_tiered::evict_tokens(uint32_t n_tokens_to_evict, llama_cache_tier from_tier) {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    // Get eviction candidates based on policy
+    auto candidates = token_metadata.get_eviction_candidates(
+        eviction_policy,
+        n_tokens_to_evict);
+
+    // Evict tokens
+    for (auto pos : candidates) {
+        // Move to cold tier or remove
+        // Implementation depends on tier architecture
+    }
+
+    stats.eviction_count += candidates.size();
+    return true;
+}
+
+bool llama_kv_cache_tiered::migrate_tokens(const std::vector<llama_pos>& positions,
+                                            llama_cache_tier from_tier,
+                                            llama_cache_tier to_tier,
+                                            const ggml_tensor* k_tensor,
+                                            const ggml_tensor* v_tensor) {
+    auto start = std::chrono::high_resolution_clock::now();
+
+    // Migration logic based on tier direction
+    // - Hot (VRAM) to Warm (RAM): copy with compression
+    // - Warm (RAM) to Cold (SSD): compress and write to SSD
+    // - Cold (SSD) to Warm/Hot: decompress and load to RAM/VRAM
+    
+    // Check if we have tensor pointers for actual data movement
+    if (k_tensor == nullptr || v_tensor == nullptr) {
+        // Metadata-only migration (no actual data movement)
+        for (auto pos : positions) {
+            token_metadata.record_access(pos);
+        }
+    } else {
+        // Actual data migration with tensor pointers
+        // Determine source and destination based on tier
+        bool is_hot_to_warm = (from_tier == TIER_HOT && to_tier == TIER_WARM);
+        bool is_warm_to_cold = (from_tier == TIER_WARM && to_tier == TIER_COLD);
+        bool is_cold_to_warm = (from_tier == TIER_COLD && to_tier == TIER_WARM);
+        bool is_cold_to_hot = (from_tier == TIER_COLD && to_tier == TIER_HOT);
+        
+        if (is_warm_to_cold) {
+            // Warm→Cold: data is already in RAM, can serialize directly
+            save_to_ssd(positions, k_tensor, v_tensor, false);  // is_device_data = false
+        } else if (is_hot_to_warm) {
+            // Hot→Warm: data is in VRAM (device), need to copy to host first
+            save_to_ssd(positions, k_tensor, v_tensor, true);  // is_device_data = true
+        } else if (is_cold_to_warm || is_cold_to_hot) {
+            // Loading from cold tier - load from SSD
+            // Note: requires mutable tensors for destination
+            load_from_ssd(positions, const_cast<ggml_tensor*>(k_tensor), const_cast<ggml_tensor*>(v_tensor), false);  // to_device = false
+        }
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    stats.total_migration_latency_us += duration.count();
+
+    return true;
+}
+
+bool llama_kv_cache_tiered::batch_migrate_tokens(const std::vector<llama_pos>& positions,
+                                                  llama_cache_tier from_tier,
+                                                  llama_cache_tier to_tier,
+                                                  const ggml_tensor* k_tensor,
+                                                  const ggml_tensor* v_tensor) {
+    auto start = std::chrono::high_resolution_clock::now();
+
+    // Batch migration optimization:
+    // - Group tokens by layer for efficient I/O
+    // - Compress data before transfer if moving to colder tier
+    // - Decompress data when loading from colder tier
+    
+    if (k_tensor == nullptr || v_tensor == nullptr) {
+        // Metadata-only batch migration
+        for (auto pos : positions) {
+            token_metadata.record_access(pos);
+        }
+    } else {
+        // Batch migration with actual data movement
+        // Group by layer for efficient I/O
+        // For AMD ROCm/HIP: use hipMemcpy for device-to-host or host-to-device transfers
+        
+        bool is_warm_to_cold = (from_tier == TIER_WARM && to_tier == TIER_COLD);
+        bool is_hot_to_warm = (from_tier == TIER_HOT && to_tier == TIER_WARM);
+        
+        if (is_warm_to_cold) {
+            // Warm→Cold: data is already in RAM, can serialize directly
+            save_to_ssd(positions, k_tensor, v_tensor, false);  // is_device_data = false
+        } else if (is_hot_to_warm) {
+            // Hot→Warm: data is in VRAM (device), need to copy to host first
+            save_to_ssd(positions, k_tensor, v_tensor, true);  // is_device_data = true
+        } else {
+            // Load from SSD
+            load_from_ssd(positions, const_cast<ggml_tensor*>(k_tensor), const_cast<ggml_tensor*>(v_tensor), false);  // to_device = false
+        }
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    stats.total_migration_latency_us += duration.count();
+
+    return true;
+}
+
+bool llama_kv_cache_tiered::prefetch_tokens(const std::vector<llama_pos>& positions,
+                                             llama_cache_tier target_tier) {
+    // Prefetch optimization:
+    // - Pre-load likely-needed tokens before they're requested
+    // - Use attention patterns to predict which tokens will be needed
+    // - Batch prefetch requests for efficiency
+
+    // TODO: Implement attention-based prediction for prefetch
+    // TODO: Implement batch prefetch with priority queue
+
+    return true;
+}
+
+bool llama_kv_cache_tiered::contains_token(llama_pos pos) const {
+    std::lock_guard<std::mutex> lock(mutex);
+    return token_metadata.get_metadata(pos) != nullptr;
+}
+
+bool llama_kv_cache_tiered::load_token(llama_pos pos, llama_cache_tier target_tier) {
+    // Check if token is in cold tier and needs to be loaded
+    std::string ssd_file = get_ssd_file_path(pos);
+    if (std::filesystem::exists(ssd_file)) {
+        // Load from SSD
+        stats.cache_hits++;
+        return true;
+    }
+    stats.cache_misses++;
+    return false;
+}
+
+llama_tier_stats llama_kv_cache_tiered::get_stats() const {
+    std::lock_guard<std::mutex> lock(mutex);
+    return stats;
+}
+
+void llama_kv_cache_tiered::reset_stats() {
+    std::lock_guard<std::mutex> lock(mutex);
+    stats.reset();
+}
+
+std::string llama_kv_cache_tiered::get_ssd_file_path(llama_pos pos) const {
+    // Generate unique file path for token position
+    return ssd_path + "/token_" + std::to_string(pos) + ".bin";
+}
+
+bool llama_kv_cache_tiered::save_to_ssd(const std::vector<llama_pos>& positions,
+                                         const ggml_tensor* k_tensor,
+                                         const ggml_tensor* v_tensor,
+                                         bool is_device_data) {
+    // Save KV cache data to SSD using the SSD storage format
+    if (positions.empty() || k_tensor == nullptr || v_tensor == nullptr) {
+        return false;
+    }
+    
+    // Calculate number of tokens and layer info
+    uint32_t n_tokens = uint32_t(positions.size());
+    uint32_t n_layers = 32;  // Default placeholder - should come from model config
+    uint32_t n_embd_k = k_tensor->ne[0];
+    uint32_t n_embd_v = v_tensor->ne[0];
+    
+    // Calculate buffer size for device-to-host copy if needed
+    // This is a simplified calculation - actual implementation should use model-specific sizes
+    size_t buffer_size = n_tokens * n_embd_k * sizeof(float);
+    size_t buffer_size_v = n_tokens * n_embd_v * sizeof(float);
+    
+    // Use the SSD storage format to write data
+    llama_ssd_storage_format ssd;
+    std::string base_path = ssd_path + "/cache";
+    
+#ifdef GGML_USE_HIP
+    // If data is on device, we need to copy to host first
+    if (is_device_data) {
+        // Allocate host buffers for staging device data
+        std::vector<float> k_host_buf(n_tokens * n_embd_k);
+        std::vector<float> v_host_buf(n_tokens * n_embd_v);
+        
+        // Copy device data to host buffer using hipMemcpy
+        hipError_t err_k = hipMemcpy(k_host_buf.data(),
+                                      (const void*)k_tensor->data,
+                                      buffer_size,
+                                      hipMemcpyDeviceToHost);
+        hipError_t err_v = hipMemcpy(v_host_buf.data(),
+                                      (const void*)v_tensor->data,
+                                      buffer_size_v,
+                                      hipMemcpyDeviceToHost);
+        
+        if (err_k != hipSuccess || err_v != hipSuccess) {
+            return false;
+        }
+        
+        // Write K and V data for each position using host-staged data
+        for (auto pos : positions) {
+            std::string file_path = base_path + "_pos_" + std::to_string(pos) + ".bin";
+            bool success = ssd.write(file_path,
+                                     k_host_buf.data(),
+                                     v_host_buf.data(),
+                                     n_tokens, n_layers, n_embd_k, n_embd_v, compression);
+            if (!success) {
+                return false;
+            }
+        }
+        return true;
+    }
+#endif
+    
+    // Non-device data path (RAM/SSD) - use tensor data directly
+    const float* k_data = (const float*)k_tensor->data;
+    const float* v_data = (const float*)v_tensor->data;
+    
+    // Write K and V data for each position
+    for (auto pos : positions) {
+        std::string file_path = base_path + "_pos_" + std::to_string(pos) + ".bin";
+        bool success = ssd.write(file_path, k_data, v_data, n_tokens, n_layers, n_embd_k, n_embd_v, compression);
+        if (!success) {
+            return false;
+        }
+    }
+    
+    return true;
+}
+
+bool llama_kv_cache_tiered::load_from_ssd(const std::vector<llama_pos>& positions,
+                                           ggml_tensor* k_tensor,
+                                           ggml_tensor* v_tensor,
+                                           bool to_device) {
+    // Load KV cache data from SSD using the SSD storage format
+    if (positions.empty() || k_tensor == nullptr || v_tensor == nullptr) {
+        return false;
+    }
+    
+    // Calculate number of tokens and layer info
+    uint32_t n_tokens = uint32_t(positions.size());
+    uint32_t n_layers = 32;  // Default placeholder - should come from model config
+    uint32_t n_embd_k = k_tensor->ne[0];
+    uint32_t n_embd_v = v_tensor->ne[0];
+    
+    // Calculate buffer size for host-to-device copy if needed
+    size_t buffer_size = n_tokens * n_embd_k * sizeof(float);
+    size_t buffer_size_v = n_tokens * n_embd_v * sizeof(float);
+    
+    // Use the SSD storage format to read data
+    llama_ssd_storage_format ssd;
+    std::string base_path = ssd_path + "/cache";
+    
+#ifdef GGML_USE_HIP
+    // If destination is device, we need to copy from host to device
+    if (to_device) {
+        // Allocate host buffer for staging before device copy
+        std::vector<float> k_host_buf(n_tokens * n_embd_k);
+        std::vector<float> v_host_buf(n_tokens * n_embd_v);
+        
+        // Read K and V data for each position into host buffer
+        for (auto pos : positions) {
+            std::string file_path = base_path + "_pos_" + std::to_string(pos) + ".bin";
+            if (!ssd.read(file_path, k_host_buf.data(), v_host_buf.data(), n_tokens, n_layers, n_embd_k, n_embd_v)) {
+                return false;
+            }
+        }
+        
+        // Copy host data to device using hipMemcpy
+        hipError_t err_k = hipMemcpy((void*)k_tensor->data,
+                                      k_host_buf.data(),
+                                      buffer_size,
+                                      hipMemcpyHostToDevice);
+        hipError_t err_v = hipMemcpy((void*)v_tensor->data,
+                                      v_host_buf.data(),
+                                      buffer_size_v,
+                                      hipMemcpyHostToDevice);
+        
+        return (err_k == hipSuccess && err_v == hipSuccess);
+    }
+#endif
+    
+    // Non-device path - read directly to tensor data
+    float* k_data = (float*)k_tensor->data;
+    float* v_data = (float*)v_tensor->data;
+    
+    // Read K and V data for each position
+    for (auto pos : positions) {
+        std::string file_path = base_path + "_pos_" + std::to_string(pos) + ".bin";
+        if (!ssd.read(file_path, k_data, v_data, n_tokens, n_layers, n_embd_k, n_embd_v)) {
+            return false;
+        }
+    }
+    
+    return true;
+}

--- a/src/llama-kv-cache-tiered.cpp
+++ b/src/llama-kv-cache-tiered.cpp
@@ -322,6 +322,39 @@ bool llama_kv_cache_tiered::init() {
     if (!std::filesystem::exists(ssd_dir)) {
         std::filesystem::create_directories(ssd_dir);
     }
+
+#ifdef GGML_USE_HIP
+    if (config.warm_device >= 0) {
+        // Allocate warm tier buffers on 6900XT (or whatever warm_device is)
+        int prev_dev = 0;
+        hipGetDevice(&prev_dev);
+        hipSetDevice(config.warm_device);
+
+        // Each warm slot holds n_kv_heads * head_dim elements per position.
+        // We allocate config.warm_ctx slots; each slot is warm_elem_bytes bytes
+        // for K and the same for V.
+        // warm_elem_bytes is set by the caller via set_warm_elem_bytes().
+        if (warm_elem_bytes > 0 && config.warm_capacity() > 0) {
+            warm_dev_capacity = warm_elem_bytes * config.warm_capacity();
+            hipError_t err_k = hipMalloc(&warm_k_dev, warm_dev_capacity);
+            hipError_t err_v = hipMalloc(&warm_v_dev, warm_dev_capacity);
+            if (err_k != hipSuccess || err_v != hipSuccess) {
+                LLAMA_LOG_WARN("%s: hipMalloc warm tier on device %d failed, falling back to SSD\n",
+                               __func__, config.warm_device);
+                if (warm_k_dev) { hipFree(warm_k_dev); warm_k_dev = nullptr; }
+                if (warm_v_dev) { hipFree(warm_v_dev); warm_v_dev = nullptr; }
+                warm_dev_capacity = 0;
+            } else {
+                warm_slots.assign(config.warm_capacity(), WarmSlot{});
+                LLAMA_LOG_INFO("%s: warm tier on device %d: %.1f MB K + %.1f MB V\n",
+                               __func__, config.warm_device,
+                               warm_dev_capacity / 1e6, warm_dev_capacity / 1e6);
+            }
+        }
+        hipSetDevice(prev_dev);
+    }
+#endif
+
     return true;
 }
 
@@ -361,6 +394,52 @@ bool llama_kv_cache_tiered::evict_tokens(uint32_t n_tokens_to_evict, llama_cache
     return true;
 }
 
+#ifdef GGML_USE_HIP
+int llama_kv_cache_tiered::warm_alloc_slot() {
+    for (int i = 0; i < (int)warm_slots.size(); i++) {
+        if (!warm_slots[i].occupied) {
+            warm_slots[i].occupied = true;
+            return i;
+        }
+    }
+    return -1;
+}
+
+void llama_kv_cache_tiered::warm_free_slot(llama_pos pos) {
+    auto it = warm_pos_to_slot.find(pos);
+    if (it != warm_pos_to_slot.end()) {
+        int slot = it->second;
+        warm_slots[slot].occupied = false;
+        warm_slots[slot].pos = -1;
+        warm_pos_to_slot.erase(it);
+    }
+}
+
+bool llama_kv_cache_tiered::warm_copy_to_device(int slot, const void * k_host, const void * v_host, size_t nbytes) {
+    if (!warm_k_dev || !warm_v_dev || slot < 0 || (size_t)slot >= warm_slots.size()) return false;
+    int prev_dev = 0;
+    hipGetDevice(&prev_dev);
+    hipSetDevice(config.warm_device);
+    size_t offset = (size_t)slot * nbytes;
+    bool ok = (hipMemcpy((char*)warm_k_dev + offset, k_host, nbytes, hipMemcpyHostToDevice) == hipSuccess) &&
+              (hipMemcpy((char*)warm_v_dev + offset, v_host, nbytes, hipMemcpyHostToDevice) == hipSuccess);
+    hipSetDevice(prev_dev);
+    return ok;
+}
+
+bool llama_kv_cache_tiered::warm_copy_from_device(int slot, void * k_host, void * v_host, size_t nbytes) {
+    if (!warm_k_dev || !warm_v_dev || slot < 0 || (size_t)slot >= warm_slots.size()) return false;
+    int prev_dev = 0;
+    hipGetDevice(&prev_dev);
+    hipSetDevice(config.warm_device);
+    size_t offset = (size_t)slot * nbytes;
+    bool ok = (hipMemcpy(k_host, (char*)warm_k_dev + offset, nbytes, hipMemcpyDeviceToHost) == hipSuccess) &&
+              (hipMemcpy(v_host, (char*)warm_v_dev + offset, nbytes, hipMemcpyDeviceToHost) == hipSuccess);
+    hipSetDevice(prev_dev);
+    return ok;
+}
+#endif  // GGML_USE_HIP
+
 bool llama_kv_cache_tiered::migrate_tokens(const std::vector<llama_pos>& positions,
                                             llama_cache_tier from_tier,
                                             llama_cache_tier to_tier,
@@ -388,15 +467,35 @@ bool llama_kv_cache_tiered::migrate_tokens(const std::vector<llama_pos>& positio
         bool is_cold_to_hot = (from_tier == TIER_COLD && to_tier == TIER_HOT);
         
         if (is_warm_to_cold) {
-            // Warm→Cold: data is already in RAM, can serialize directly
-            save_to_ssd(positions, k_tensor, v_tensor, false);  // is_device_data = false
+            // Warm→Cold: serialize to SSD
+            save_to_ssd(positions, k_tensor, v_tensor, false);
         } else if (is_hot_to_warm) {
-            // Hot→Warm: data is in VRAM (device), need to copy to host first
-            save_to_ssd(positions, k_tensor, v_tensor, true);  // is_device_data = true
+#ifdef GGML_USE_HIP
+            if (warm_k_dev && warm_elem_bytes > 0) {
+                // R9700 VRAM → host staging → 6900XT VRAM
+                size_t nbytes = warm_elem_bytes;
+                std::vector<uint8_t> k_buf(nbytes), v_buf(nbytes);
+                // copy device→host on current (hot) device
+                hipMemcpy(k_buf.data(), k_tensor->data, nbytes, hipMemcpyDeviceToHost);
+                hipMemcpy(v_buf.data(), v_tensor->data, nbytes, hipMemcpyDeviceToHost);
+                for (auto pos : positions) {
+                    int slot = warm_alloc_slot();
+                    if (slot < 0) {
+                        // warm tier full — spill to SSD
+                        save_to_ssd({pos}, k_tensor, v_tensor, true);
+                        continue;
+                    }
+                    warm_copy_to_device(slot, k_buf.data(), v_buf.data(), nbytes);
+                    warm_slots[slot].pos = pos;
+                    warm_pos_to_slot[pos] = slot;
+                }
+            } else
+#endif
+            {
+                save_to_ssd(positions, k_tensor, v_tensor, true);
+            }
         } else if (is_cold_to_warm || is_cold_to_hot) {
-            // Loading from cold tier - load from SSD
-            // Note: requires mutable tensors for destination
-            load_from_ssd(positions, const_cast<ggml_tensor*>(k_tensor), const_cast<ggml_tensor*>(v_tensor), false);  // to_device = false
+            load_from_ssd(positions, const_cast<ggml_tensor*>(k_tensor), const_cast<ggml_tensor*>(v_tensor), false);
         }
     }
 
@@ -433,14 +532,31 @@ bool llama_kv_cache_tiered::batch_migrate_tokens(const std::vector<llama_pos>& p
         bool is_hot_to_warm = (from_tier == TIER_HOT && to_tier == TIER_WARM);
         
         if (is_warm_to_cold) {
-            // Warm→Cold: data is already in RAM, can serialize directly
-            save_to_ssd(positions, k_tensor, v_tensor, false);  // is_device_data = false
+            save_to_ssd(positions, k_tensor, v_tensor, false);
         } else if (is_hot_to_warm) {
-            // Hot→Warm: data is in VRAM (device), need to copy to host first
-            save_to_ssd(positions, k_tensor, v_tensor, true);  // is_device_data = true
+#ifdef GGML_USE_HIP
+            if (warm_k_dev && warm_elem_bytes > 0) {
+                size_t nbytes = warm_elem_bytes;
+                std::vector<uint8_t> k_buf(nbytes), v_buf(nbytes);
+                hipMemcpy(k_buf.data(), k_tensor->data, nbytes, hipMemcpyDeviceToHost);
+                hipMemcpy(v_buf.data(), v_tensor->data, nbytes, hipMemcpyDeviceToHost);
+                for (auto pos : positions) {
+                    int slot = warm_alloc_slot();
+                    if (slot < 0) {
+                        save_to_ssd({pos}, k_tensor, v_tensor, true);
+                        continue;
+                    }
+                    warm_copy_to_device(slot, k_buf.data(), v_buf.data(), nbytes);
+                    warm_slots[slot].pos = pos;
+                    warm_pos_to_slot[pos] = slot;
+                }
+            } else
+#endif
+            {
+                save_to_ssd(positions, k_tensor, v_tensor, true);
+            }
         } else {
-            // Load from SSD
-            load_from_ssd(positions, const_cast<ggml_tensor*>(k_tensor), const_cast<ggml_tensor*>(v_tensor), false);  // to_device = false
+            load_from_ssd(positions, const_cast<ggml_tensor*>(k_tensor), const_cast<ggml_tensor*>(v_tensor), false);
         }
     }
 

--- a/src/llama-kv-cache-tiered.cpp
+++ b/src/llama-kv-cache-tiered.cpp
@@ -313,7 +313,14 @@ llama_kv_cache_tiered::llama_kv_cache_tiered(
 }
 
 llama_kv_cache_tiered::~llama_kv_cache_tiered() {
-    // Cleanup
+    for (auto & tl : kv_layers) {
+        delete[] tl.warm_k;
+        delete[] tl.warm_v;
+#ifdef GGML_USE_HIP
+        if (tl.warm_k_dev) { hipFree(tl.warm_k_dev); }
+        if (tl.warm_v_dev) { hipFree(tl.warm_v_dev); }
+#endif
+    }
 }
 
 bool llama_kv_cache_tiered::init() {
@@ -323,37 +330,12 @@ bool llama_kv_cache_tiered::init() {
         std::filesystem::create_directories(ssd_dir);
     }
 
-#ifdef GGML_USE_HIP
-    if (config.warm_device >= 0) {
-        // Allocate warm tier buffers on 6900XT (or whatever warm_device is)
-        int prev_dev = 0;
-        hipGetDevice(&prev_dev);
-        hipSetDevice(config.warm_device);
-
-        // Each warm slot holds n_kv_heads * head_dim elements per position.
-        // We allocate config.warm_ctx slots; each slot is warm_elem_bytes bytes
-        // for K and the same for V.
-        // warm_elem_bytes is set by the caller via set_warm_elem_bytes().
-        if (warm_elem_bytes > 0 && config.warm_capacity() > 0) {
-            warm_dev_capacity = warm_elem_bytes * config.warm_capacity();
-            hipError_t err_k = hipMalloc(&warm_k_dev, warm_dev_capacity);
-            hipError_t err_v = hipMalloc(&warm_v_dev, warm_dev_capacity);
-            if (err_k != hipSuccess || err_v != hipSuccess) {
-                LLAMA_LOG_WARN("%s: hipMalloc warm tier on device %d failed, falling back to SSD\n",
-                               __func__, config.warm_device);
-                if (warm_k_dev) { hipFree(warm_k_dev); warm_k_dev = nullptr; }
-                if (warm_v_dev) { hipFree(warm_v_dev); warm_v_dev = nullptr; }
-                warm_dev_capacity = 0;
-            } else {
-                warm_slots.assign(config.warm_capacity(), WarmSlot{});
-                LLAMA_LOG_INFO("%s: warm tier on device %d: %.1f MB K + %.1f MB V\n",
-                               __func__, config.warm_device,
-                               warm_dev_capacity / 1e6, warm_dev_capacity / 1e6);
-            }
-        }
-        hipSetDevice(prev_dev);
+    // Warm slot tracking — per-layer buffers allocated later in set_kv_layers_from_cache()
+    if (config.warm_capacity() > 0) {
+        warm_slots.assign(config.warm_capacity(), WarmSlot{});
+        LLAMA_LOG_INFO("%s: warm tier: %u slots reserved (buffers wired after KV layers available)\n",
+                       __func__, config.warm_capacity());
     }
-#endif
 
     return true;
 }
@@ -376,25 +358,59 @@ bool llama_kv_cache_tiered::set_attention_threshold(float threshold) {
     return true;
 }
 
+void llama_kv_cache_tiered::track_hot_range(uint32_t n_hot) {
+    std::lock_guard<std::mutex> lock(mutex);
+    for (uint32_t p = 0; p < n_hot; p++) {
+        token_metadata.record_access((llama_pos)p);
+    }
+    stats.hot_tokens = n_hot;
+}
+
 bool llama_kv_cache_tiered::evict_tokens(uint32_t n_tokens_to_evict, llama_cache_tier from_tier) {
     std::lock_guard<std::mutex> lock(mutex);
 
-    // Get eviction candidates based on policy
-    auto candidates = token_metadata.get_eviction_candidates(
-        eviction_policy,
-        n_tokens_to_evict);
+    auto candidates = token_metadata.get_eviction_candidates(eviction_policy, n_tokens_to_evict);
+    if (candidates.empty()) {
+        return false;
+    }
 
-    // Evict tokens
+    std::vector<llama_pos> to_warm, to_cold;
+
+    // Route to warm if slots available (RAM or GPU), otherwise cold
+    int free_warm = 0;
+    for (const auto & s : warm_slots) {
+        if (!s.occupied) free_warm++;
+    }
     for (auto pos : candidates) {
-        // Move to cold tier or remove
-        // Implementation depends on tier architecture
+        if (free_warm > 0) {
+            to_warm.push_back(pos);
+            free_warm--;
+        } else {
+            to_cold.push_back(pos);
+        }
+    }
+
+    // migrate_tokens handles null k_tensor/v_tensor as metadata-only (no-copy) path
+    if (!to_warm.empty()) {
+        migrate_tokens(to_warm, TIER_HOT, TIER_WARM);
+        stats.warm_tokens += (uint32_t)to_warm.size();
+        stats.hot_tokens   = stats.hot_tokens >= (uint32_t)to_warm.size()
+                           ? stats.hot_tokens - (uint32_t)to_warm.size() : 0;
+        LLAMA_LOG_INFO("%s: evicted %zu hot->warm\n", __func__, to_warm.size());
+    }
+    if (!to_cold.empty()) {
+        migrate_tokens(to_cold, TIER_HOT, TIER_COLD);
+        stats.cold_tokens += (uint32_t)to_cold.size();
+        stats.hot_tokens   = stats.hot_tokens >= (uint32_t)to_cold.size()
+                           ? stats.hot_tokens - (uint32_t)to_cold.size() : 0;
+        LLAMA_LOG_INFO("%s: evicted %zu hot->cold\n", __func__, to_cold.size());
     }
 
     stats.eviction_count += candidates.size();
     return true;
 }
 
-#ifdef GGML_USE_HIP
+// Warm slot management — unconditional (works for RAM and GPU warm tiers)
 int llama_kv_cache_tiered::warm_alloc_slot() {
     for (int i = 0; i < (int)warm_slots.size(); i++) {
         if (!warm_slots[i].occupied) {
@@ -415,95 +431,289 @@ void llama_kv_cache_tiered::warm_free_slot(llama_pos pos) {
     }
 }
 
-bool llama_kv_cache_tiered::warm_copy_to_device(int slot, const void * k_host, const void * v_host, size_t nbytes) {
-    if (!warm_k_dev || !warm_v_dev || slot < 0 || (size_t)slot >= warm_slots.size()) return false;
-    int prev_dev = 0;
-    hipGetDevice(&prev_dev);
-    hipSetDevice(config.warm_device);
-    size_t offset = (size_t)slot * nbytes;
-    bool ok = (hipMemcpy((char*)warm_k_dev + offset, k_host, nbytes, hipMemcpyHostToDevice) == hipSuccess) &&
-              (hipMemcpy((char*)warm_v_dev + offset, v_host, nbytes, hipMemcpyHostToDevice) == hipSuccess);
-    hipSetDevice(prev_dev);
-    return ok;
+// Copy one token's K data from VRAM (or host) into warm slot — K is always contiguous
+bool llama_kv_cache_tiered::warm_copy_to_host(uint32_t il, int slot, llama_pos pos) {
+    if (il >= kv_layers.size() || slot < 0 || (size_t)slot >= warm_slots.size()) return false;
+    const auto & tl = kv_layers[il];
+    if (!tl.k || !tl.warm_k || !tl.v || !tl.warm_v) return false;
+
+    const size_t elem_k = ggml_element_size(tl.k);
+    const size_t n_embd_k = (size_t)tl.k->ne[0];
+    uint8_t * dst_k = tl.warm_k + (size_t)slot * tl.k_bytes;
+
+    // K: contiguous row at pos — single copy
+#ifdef GGML_USE_HIP
+    hipMemcpy(dst_k, (uint8_t *)tl.k->data + (size_t)pos * tl.k_bytes, tl.k_bytes, hipMemcpyDeviceToHost);
+#else
+    memcpy(dst_k, (uint8_t *)tl.k->data + (size_t)pos * tl.k_bytes, tl.k_bytes);
+#endif
+
+    const size_t elem_v = ggml_element_size(tl.v);
+    const size_t n_embd_v = (size_t)tl.v->ne[0];
+    uint8_t * dst_v = tl.warm_v + (size_t)slot * tl.v_bytes;
+
+    if (!tl.v_trans) {
+        // V: also contiguous when not transposed
+#ifdef GGML_USE_HIP
+        hipMemcpy(dst_v, (uint8_t *)tl.v->data + (size_t)pos * tl.v_bytes, tl.v_bytes, hipMemcpyDeviceToHost);
+#else
+        memcpy(dst_v, (uint8_t *)tl.v->data + (size_t)pos * tl.v_bytes, tl.v_bytes);
+#endif
+    } else {
+        // V transposed: element j at (j*kv_size + pos)*elem_v — gather into contiguous warm buf
+        // Use hipMemcpy2D (src column → dst row): copies n_embd_v elements, each elem_v bytes apart
+#ifdef GGML_USE_HIP
+        hipMemcpy2D(dst_v,                                          // dst (contiguous)
+                    elem_v,                                          // dst pitch
+                    (uint8_t *)tl.v->data + (size_t)pos * elem_v,  // src (column pos)
+                    (size_t)tl.kv_size * elem_v,                    // src pitch (stride between rows)
+                    elem_v,                                          // width per row
+                    n_embd_v,                                        // number of rows
+                    hipMemcpyDeviceToHost);
+#else
+        for (size_t j = 0; j < n_embd_v; j++) {
+            memcpy(dst_v + j * elem_v,
+                   (uint8_t *)tl.v->data + ((size_t)j * (size_t)tl.kv_size + (size_t)pos) * elem_v,
+                   elem_v);
+        }
+#endif
+    }
+    return true;
 }
 
-bool llama_kv_cache_tiered::warm_copy_from_device(int slot, void * k_host, void * v_host, size_t nbytes) {
-    if (!warm_k_dev || !warm_v_dev || slot < 0 || (size_t)slot >= warm_slots.size()) return false;
-    int prev_dev = 0;
-    hipGetDevice(&prev_dev);
-    hipSetDevice(config.warm_device);
-    size_t offset = (size_t)slot * nbytes;
-    bool ok = (hipMemcpy(k_host, (char*)warm_k_dev + offset, nbytes, hipMemcpyDeviceToHost) == hipSuccess) &&
-              (hipMemcpy(v_host, (char*)warm_v_dev + offset, nbytes, hipMemcpyDeviceToHost) == hipSuccess);
+// Restore one token's K/V from warm slot back into the hot VRAM tensor
+bool llama_kv_cache_tiered::warm_copy_from_host(uint32_t il, int slot, llama_pos pos) {
+    if (il >= kv_layers.size() || slot < 0 || (size_t)slot >= warm_slots.size()) return false;
+    const auto & tl = kv_layers[il];
+    if (!tl.k || !tl.warm_k || !tl.v || !tl.warm_v) return false;
+
+    const size_t elem_k = ggml_element_size(tl.k);
+    const size_t n_embd_k = (size_t)tl.k->ne[0];
+    const uint8_t * src_k = tl.warm_k + (size_t)slot * tl.k_bytes;
+
+#ifdef GGML_USE_HIP
+    hipMemcpy((uint8_t *)tl.k->data + (size_t)pos * tl.k_bytes, src_k, tl.k_bytes, hipMemcpyHostToDevice);
+#else
+    memcpy((uint8_t *)tl.k->data + (size_t)pos * tl.k_bytes, src_k, tl.k_bytes);
+#endif
+
+    const size_t elem_v = ggml_element_size(tl.v);
+    const size_t n_embd_v = (size_t)tl.v->ne[0];
+    const uint8_t * src_v = tl.warm_v + (size_t)slot * tl.v_bytes;
+
+    if (!tl.v_trans) {
+#ifdef GGML_USE_HIP
+        hipMemcpy((uint8_t *)tl.v->data + (size_t)pos * tl.v_bytes, src_v, tl.v_bytes, hipMemcpyHostToDevice);
+#else
+        memcpy((uint8_t *)tl.v->data + (size_t)pos * tl.v_bytes, src_v, tl.v_bytes);
+#endif
+    } else {
+        // Scatter: warm contiguous → V transposed column at pos
+#ifdef GGML_USE_HIP
+        hipMemcpy2D((uint8_t *)tl.v->data + (size_t)pos * elem_v,  // dst column pos
+                    (size_t)tl.kv_size * elem_v,                     // dst pitch
+                    src_v,                                            // src (contiguous)
+                    elem_v,                                           // src pitch
+                    elem_v,                                           // width
+                    n_embd_v,                                         // height
+                    hipMemcpyHostToDevice);
+#else
+        for (size_t j = 0; j < n_embd_v; j++) {
+            memcpy((uint8_t *)tl.v->data + ((size_t)j * (size_t)tl.kv_size + (size_t)pos) * elem_v,
+                   src_v + j * elem_v,
+                   elem_v);
+        }
+#endif
+    }
+    return true;
+}
+
+#ifdef GGML_USE_HIP
+// VRAM (R9700) → device VRAM (6900XT warm tier): K contiguous, V gather/scatter
+bool llama_kv_cache_tiered::warm_copy_to_dev(uint32_t il, int slot, llama_pos pos) {
+    if (il >= kv_layers.size() || slot < 0 || (size_t)slot >= warm_slots.size()) return false;
+    const auto & tl = kv_layers[il];
+    if (!tl.warm_k_dev || !tl.warm_v_dev || !tl.k || !tl.v) return false;
+    int prev_dev = 0; hipGetDevice(&prev_dev); hipSetDevice(config.warm_device);
+    // K: contiguous D2D copy
+    hipMemcpy((uint8_t *)tl.warm_k_dev + (size_t)slot * tl.k_bytes,
+              (uint8_t *)tl.k->data   + (size_t)pos  * tl.k_bytes,
+              tl.k_bytes, hipMemcpyDeviceToDevice);
+    const size_t ev = ggml_element_size(tl.v);
+    const size_t nv = (size_t)tl.v->ne[0]; // n_embd_v_gqa
+    if (!tl.v_trans) {
+        hipMemcpy((uint8_t *)tl.warm_v_dev + (size_t)slot * tl.v_bytes,
+                  (uint8_t *)tl.v->data   + (size_t)pos  * tl.v_bytes,
+                  tl.v_bytes, hipMemcpyDeviceToDevice);
+    } else {
+        // Gather column pos into contiguous warm buf
+        hipMemcpy2D((uint8_t *)tl.warm_v_dev + (size_t)slot * tl.v_bytes, ev,
+                    (uint8_t *)tl.v->data    + (size_t)pos  * ev,
+                    (size_t)tl.kv_size * ev, ev, nv, hipMemcpyDeviceToDevice);
+    }
     hipSetDevice(prev_dev);
-    return ok;
+    return true;
+}
+
+bool llama_kv_cache_tiered::warm_copy_from_dev(uint32_t il, int slot, llama_pos pos) {
+    if (il >= kv_layers.size() || slot < 0 || (size_t)slot >= warm_slots.size()) return false;
+    const auto & tl = kv_layers[il];
+    if (!tl.warm_k_dev || !tl.warm_v_dev || !tl.k || !tl.v) return false;
+    int prev_dev = 0; hipGetDevice(&prev_dev); hipSetDevice(config.warm_device);
+    hipMemcpy((uint8_t *)tl.k->data    + (size_t)pos  * tl.k_bytes,
+              (uint8_t *)tl.warm_k_dev + (size_t)slot * tl.k_bytes,
+              tl.k_bytes, hipMemcpyDeviceToDevice);
+    const size_t ev = ggml_element_size(tl.v);
+    const size_t nv = (size_t)tl.v->ne[0];
+    if (!tl.v_trans) {
+        hipMemcpy((uint8_t *)tl.v->data    + (size_t)pos  * tl.v_bytes,
+                  (uint8_t *)tl.warm_v_dev + (size_t)slot * tl.v_bytes,
+                  tl.v_bytes, hipMemcpyDeviceToDevice);
+    } else {
+        hipMemcpy2D((uint8_t *)tl.v->data    + (size_t)pos  * ev,
+                    (size_t)tl.kv_size * ev,
+                    (uint8_t *)tl.warm_v_dev + (size_t)slot * tl.v_bytes, ev,
+                    ev, nv, hipMemcpyDeviceToDevice);
+    }
+    hipSetDevice(prev_dev);
+    return true;
 }
 #endif  // GGML_USE_HIP
+
+void llama_kv_cache_tiered::set_kv_layers_from_cache(llama_kv_cache * cache) {
+    if (!cache) return;
+    std::lock_guard<std::mutex> lock(mutex);
+
+    uint32_t n = cache->get_num_kv_layers();
+    bool vtrans = cache->is_v_transposed();
+    int64_t kvsz = (int64_t)cache->get_size();
+
+    kv_layers.resize(n);
+    for (uint32_t il = 0; il < n; il++) {
+        auto & tl = kv_layers[il];
+        tl.k      = cache->get_layer_k_raw(il);
+        tl.v      = cache->get_layer_v_raw(il);
+        tl.v_trans = vtrans;
+        tl.kv_size = kvsz;
+        if (tl.k) tl.k_bytes = (size_t)tl.k->ne[0] * ggml_element_size(tl.k);
+        if (tl.v) tl.v_bytes = (size_t)tl.v->ne[0] * ggml_element_size(tl.v);
+    }
+
+    // (Re)allocate per-layer warm buffers using already-reserved slot count
+    uint32_t n_warm = (uint32_t)warm_slots.size();
+    if (n_warm == 0 && config.warm_capacity() > 0) {
+        n_warm = config.warm_capacity();
+        warm_slots.assign(n_warm, WarmSlot{});
+    }
+
+    for (auto & tl : kv_layers) {
+        delete[] tl.warm_k;
+        delete[] tl.warm_v;
+        tl.warm_k = tl.warm_v = nullptr;
+        if (n_warm > 0 && tl.k_bytes > 0) tl.warm_k = new uint8_t[n_warm * tl.k_bytes]();
+        if (n_warm > 0 && tl.v_bytes > 0) tl.warm_v = new uint8_t[n_warm * tl.v_bytes]();
+
+#ifdef GGML_USE_HIP
+        if (config.warm_device >= 0 && n_warm > 0) {
+            hipSetDevice(config.warm_device);
+            if (tl.warm_k_dev) hipFree(tl.warm_k_dev);
+            if (tl.warm_v_dev) hipFree(tl.warm_v_dev);
+            tl.warm_k_dev = tl.warm_v_dev = nullptr;
+            if (tl.k_bytes > 0) hipMalloc(&tl.warm_k_dev, n_warm * tl.k_bytes);
+            if (tl.v_bytes > 0) hipMalloc(&tl.warm_v_dev, n_warm * tl.v_bytes);
+        }
+#endif
+    }
+
+    size_t total_mb = 0;
+    for (const auto & tl : kv_layers)
+        total_mb += (tl.k_bytes + tl.v_bytes) * n_warm;
+    total_mb /= (1024*1024);
+
+    LLAMA_LOG_INFO("%s: wired %u KV layers (v_trans=%d, kv_size=%lld), warm RAM: ~%zu MB (%u slots x %u layers)\n",
+                   __func__, n, (int)vtrans, (long long)kvsz, total_mb, n_warm, n);
+}
 
 bool llama_kv_cache_tiered::migrate_tokens(const std::vector<llama_pos>& positions,
                                             llama_cache_tier from_tier,
                                             llama_cache_tier to_tier,
-                                            const ggml_tensor* k_tensor,
-                                            const ggml_tensor* v_tensor) {
+                                            const ggml_tensor* /*unused_k*/,
+                                            const ggml_tensor* /*unused_v*/) {
     auto start = std::chrono::high_resolution_clock::now();
+    bool success = true;
 
-    // Migration logic based on tier direction
-    // - Hot (VRAM) to Warm (RAM): copy with compression
-    // - Warm (RAM) to Cold (SSD): compress and write to SSD
-    // - Cold (SSD) to Warm/Hot: decompress and load to RAM/VRAM
-    
-    // Check if we have tensor pointers for actual data movement
-    if (k_tensor == nullptr || v_tensor == nullptr) {
-        // Metadata-only migration (no actual data movement)
+    if (kv_layers.empty() || warm_slots.empty()) {
+        // Metadata-only path: layer tensors not yet wired (set_kv_layers_from_cache not called)
         for (auto pos : positions) {
             token_metadata.record_access(pos);
         }
     } else {
-        // Actual data migration with tensor pointers
-        // Determine source and destination based on tier
-        bool is_hot_to_warm = (from_tier == TIER_HOT && to_tier == TIER_WARM);
-        bool is_warm_to_cold = (from_tier == TIER_WARM && to_tier == TIER_COLD);
-        bool is_cold_to_warm = (from_tier == TIER_COLD && to_tier == TIER_WARM);
-        bool is_cold_to_hot = (from_tier == TIER_COLD && to_tier == TIER_HOT);
-        
-        if (is_warm_to_cold) {
-            // Warm→Cold: serialize to SSD
-            save_to_ssd(positions, k_tensor, v_tensor, false);
-        } else if (is_hot_to_warm) {
-#ifdef GGML_USE_HIP
-            if (warm_k_dev && warm_elem_bytes > 0) {
-                // R9700 VRAM → host staging → 6900XT VRAM
-                size_t nbytes = warm_elem_bytes;
-                std::vector<uint8_t> k_buf(nbytes), v_buf(nbytes);
-                // copy device→host on current (hot) device
-                hipMemcpy(k_buf.data(), k_tensor->data, nbytes, hipMemcpyDeviceToHost);
-                hipMemcpy(v_buf.data(), v_tensor->data, nbytes, hipMemcpyDeviceToHost);
-                for (auto pos : positions) {
-                    int slot = warm_alloc_slot();
-                    if (slot < 0) {
-                        // warm tier full — spill to SSD
-                        save_to_ssd({pos}, k_tensor, v_tensor, true);
-                        continue;
-                    }
-                    warm_copy_to_device(slot, k_buf.data(), v_buf.data(), nbytes);
-                    warm_slots[slot].pos = pos;
-                    warm_pos_to_slot[pos] = slot;
+        bool is_hot_to_warm  = (from_tier == TIER_HOT  && to_tier == TIER_WARM);
+        bool is_warm_to_cold = (from_tier == TIER_WARM  && to_tier == TIER_COLD);
+        bool is_cold_to_hot  = (from_tier == TIER_COLD  && to_tier == TIER_HOT);
+        bool is_cold_to_warm = (from_tier == TIER_COLD  && to_tier == TIER_WARM);
+        bool is_warm_to_hot  = (from_tier == TIER_WARM  && to_tier == TIER_HOT);
+
+        if (is_hot_to_warm) {
+            // VRAM → RAM (or eGPU): copy K/V for every layer and every evicted position
+            for (auto pos : positions) {
+                int slot = warm_alloc_slot();
+                if (slot < 0) {
+                    LLAMA_LOG_WARN("%s: warm full, dropping pos %d (cold SSD TODO)\n", __func__, pos);
+                    token_metadata.record_access(pos);
+                    continue;
                 }
-            } else
+                warm_slots[slot].pos = pos;
+                warm_pos_to_slot[pos] = slot;
+
+                for (uint32_t il = 0; il < (uint32_t)kv_layers.size(); il++) {
+#ifdef GGML_USE_HIP
+                    if (kv_layers[il].warm_k_dev) {
+                        success &= warm_copy_to_dev(il, slot, pos);
+                    } else {
+                        success &= warm_copy_to_host(il, slot, pos);
+                    }
+#else
+                    success &= warm_copy_to_host(il, slot, pos);
 #endif
-            {
-                save_to_ssd(positions, k_tensor, v_tensor, true);
+                }
+                token_metadata.record_access(pos);
             }
-        } else if (is_cold_to_warm || is_cold_to_hot) {
-            load_from_ssd(positions, const_cast<ggml_tensor*>(k_tensor), const_cast<ggml_tensor*>(v_tensor), false);
+            if (success)
+                LLAMA_LOG_INFO("%s: hot→warm: %zu positions x %zu layers\n",
+                               __func__, positions.size(), kv_layers.size());
+        } else if (is_warm_to_hot) {
+            // RAM (or eGPU) → VRAM: restore
+            for (auto pos : positions) {
+                auto it = warm_pos_to_slot.find(pos);
+                if (it == warm_pos_to_slot.end()) continue;
+                int slot = it->second;
+                for (uint32_t il = 0; il < (uint32_t)kv_layers.size(); il++) {
+#ifdef GGML_USE_HIP
+                    if (kv_layers[il].warm_k_dev) {
+                        success &= warm_copy_from_dev(il, slot, pos);
+                    } else {
+                        success &= warm_copy_from_host(il, slot, pos);
+                    }
+#else
+                    success &= warm_copy_from_host(il, slot, pos);
+#endif
+                }
+                warm_free_slot(pos);
+                token_metadata.record_access(pos);
+            }
+        } else if (is_warm_to_cold || is_cold_to_hot || is_cold_to_warm) {
+            // SSD paths: TODO — per-layer serialization
+            for (auto pos : positions) {
+                token_metadata.record_access(pos);
+            }
         }
     }
 
     auto end = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-    stats.total_migration_latency_us += duration.count();
-
-    return true;
+    stats.total_migration_latency_us +=
+        (double)std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+    return success;
 }
 
 bool llama_kv_cache_tiered::batch_migrate_tokens(const std::vector<llama_pos>& positions,
@@ -513,58 +723,8 @@ bool llama_kv_cache_tiered::batch_migrate_tokens(const std::vector<llama_pos>& p
                                                   const ggml_tensor* v_tensor) {
     auto start = std::chrono::high_resolution_clock::now();
 
-    // Batch migration optimization:
-    // - Group tokens by layer for efficient I/O
-    // - Compress data before transfer if moving to colder tier
-    // - Decompress data when loading from colder tier
-    
-    if (k_tensor == nullptr || v_tensor == nullptr) {
-        // Metadata-only batch migration
-        for (auto pos : positions) {
-            token_metadata.record_access(pos);
-        }
-    } else {
-        // Batch migration with actual data movement
-        // Group by layer for efficient I/O
-        // For AMD ROCm/HIP: use hipMemcpy for device-to-host or host-to-device transfers
-        
-        bool is_warm_to_cold = (from_tier == TIER_WARM && to_tier == TIER_COLD);
-        bool is_hot_to_warm = (from_tier == TIER_HOT && to_tier == TIER_WARM);
-        
-        if (is_warm_to_cold) {
-            save_to_ssd(positions, k_tensor, v_tensor, false);
-        } else if (is_hot_to_warm) {
-#ifdef GGML_USE_HIP
-            if (warm_k_dev && warm_elem_bytes > 0) {
-                size_t nbytes = warm_elem_bytes;
-                std::vector<uint8_t> k_buf(nbytes), v_buf(nbytes);
-                hipMemcpy(k_buf.data(), k_tensor->data, nbytes, hipMemcpyDeviceToHost);
-                hipMemcpy(v_buf.data(), v_tensor->data, nbytes, hipMemcpyDeviceToHost);
-                for (auto pos : positions) {
-                    int slot = warm_alloc_slot();
-                    if (slot < 0) {
-                        save_to_ssd({pos}, k_tensor, v_tensor, true);
-                        continue;
-                    }
-                    warm_copy_to_device(slot, k_buf.data(), v_buf.data(), nbytes);
-                    warm_slots[slot].pos = pos;
-                    warm_pos_to_slot[pos] = slot;
-                }
-            } else
-#endif
-            {
-                save_to_ssd(positions, k_tensor, v_tensor, true);
-            }
-        } else {
-            load_from_ssd(positions, const_cast<ggml_tensor*>(k_tensor), const_cast<ggml_tensor*>(v_tensor), false);
-        }
-    }
-
-    auto end = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-    stats.total_migration_latency_us += duration.count();
-
-    return true;
+    // Delegate to migrate_tokens which handles the real per-layer data movement
+    return migrate_tokens(positions, from_tier, to_tier);
 }
 
 bool llama_kv_cache_tiered::prefetch_tokens(const std::vector<llama_pos>& positions,

--- a/src/llama-kv-cache-tiered.cpp
+++ b/src/llama-kv-cache-tiered.cpp
@@ -374,6 +374,62 @@ bool llama_kv_cache_tiered::evict_tokens(uint32_t n_tokens_to_evict, llama_cache
         return false;
     }
 
+    // Apply semantic eviction weighting if we have a current query embedding
+    if (!current_query_emb.empty() && !fingerprints.empty()) {
+        std::vector<std::pair<llama_pos, float>> candidates_with_similarity;
+        
+        for (auto pos : candidates) {
+            float similarity = 0.0f; // Default similarity if no fingerprint found
+            
+            // Find fingerprint for this position
+            for (const auto& fp : fingerprints) {
+                bool found = false;
+                for (auto fp_pos : fp.positions) {
+                    if (fp_pos == pos) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (found) {
+                    // Compute cosine similarity (dot product since both are L2-normalized)
+                    similarity = 0.0f;
+                    for (size_t i = 0; i < current_query_emb.size() && i < fp.embedding.size(); i++) {
+                        similarity += current_query_emb[i] * fp.embedding[i];
+                    }
+                    break;
+                }
+            }
+            
+            candidates_with_similarity.emplace_back(pos, similarity);
+        }
+        
+        // Reorder candidates: positions with similarity < 0.3 evicted first,
+        // positions with similarity > 0.65 moved to back of eviction queue
+        std::sort(candidates_with_similarity.begin(), candidates_with_similarity.end(),
+                  [](const auto& a, const auto& b) {
+                      if (a.second > 0.65f) return false;  // Keep high similarity at back
+                      if (b.second > 0.65f) return true;   // Keep high similarity at back
+                      if (a.second < 0.3f) return true;    // Evict low similarity first
+                      if (b.second < 0.3f) return false;   // Evict low similarity first
+                      return a.second < b.second;          // Otherwise by similarity
+                  });
+        
+        // Update candidates with reordered positions
+        candidates.clear();
+        for (const auto& candidate : candidates_with_similarity) {
+            candidates.push_back(candidate.first);
+        }
+        
+        // Count semantic eviction saves
+        uint32_t saves = 0;
+        for (const auto& candidate : candidates_with_similarity) {
+            if (candidate.second > 0.65f) {
+                saves++;
+            }
+        }
+        stats.semantic_eviction_saves += saves;
+    }
+
     std::vector<llama_pos> to_warm, to_cold;
 
     // Route to warm if slots available (RAM or GPU), otherwise cold
@@ -765,6 +821,145 @@ llama_tier_stats llama_kv_cache_tiered::get_stats() const {
 void llama_kv_cache_tiered::reset_stats() {
     std::lock_guard<std::mutex> lock(mutex);
     stats.reset();
+}
+
+void llama_kv_cache_tiered::add_fingerprint(const std::vector<llama_pos>& positions,
+                                             const std::vector<float>& embedding,
+                                             llama_cache_tier tier) {
+    std::lock_guard<std::mutex> lock(mutex);
+    
+    semantic_fingerprint fp;
+    fp.positions = positions;
+    fp.embedding = embedding;
+    fp.tier = tier;
+    fp.turn = fingerprint_turn++;
+    
+    // Cap at 1000 entries - evict oldest when over cap
+    if (fingerprints.size() >= 1000) {
+        fingerprints.erase(fingerprints.begin());
+    }
+    
+    fingerprints.push_back(fp);
+}
+
+std::vector<llama_kv_cache_tiered::PrefetchHint> llama_kv_cache_tiered::score_fingerprints(
+    const std::vector<float>& query_emb, int top_k, float threshold) const {
+    std::lock_guard<std::mutex> lock(mutex);
+    
+    std::vector<PrefetchHint> results;
+    
+    if (fingerprints.empty() || query_emb.empty()) {
+        return results;
+    }
+    
+    // Compute cosine similarity between query_emb and each fingerprint
+    // Since both are L2-normalized, cosine similarity = dot product
+    for (const auto& fp : fingerprints) {
+        // Compute dot product
+        float dot_product = 0.0f;
+        size_t min_size = std::min(query_emb.size(), fp.embedding.size());
+        for (size_t i = 0; i < min_size; ++i) {
+            dot_product += query_emb[i] * fp.embedding[i];
+        }
+        
+        // Check if above threshold
+        if (dot_product >= threshold) {
+            PrefetchHint hint;
+            hint.positions = fp.positions;
+            hint.score = dot_product;
+            hint.current_tier = fp.tier;
+            results.push_back(hint);
+        }
+    }
+    
+    // Sort by score descending
+    std::sort(results.begin(), results.end(),
+              [](const PrefetchHint& a, const PrefetchHint& b) {
+                  return a.score > b.score;
+              });
+    
+    // Return top_k results
+    if (static_cast<int>(results.size()) > top_k) {
+        results.resize(top_k);
+    }
+    
+    return results;
+}
+
+void llama_kv_cache_tiered::set_current_query_embedding(const std::vector<float>& emb) {
+    std::lock_guard<std::mutex> lock(mutex);
+    current_query_emb = emb;
+}
+
+bool llama_kv_cache_tiered::save_fingerprints_to_disk(const std::string& path) {
+    std::lock_guard<std::mutex> lock(mutex);
+    
+    std::ofstream file(path, std::ofstream::binary);
+    if (!file) {
+        return false;
+    }
+    
+    // Write number of entries
+    uint32_t n_entries = uint32_t(fingerprints.size());
+    file.write(reinterpret_cast<char*>(&n_entries), sizeof(uint32_t));
+    
+    // Write each fingerprint
+    for (const auto& fp : fingerprints) {
+        // Write positions count and positions
+        uint32_t n_pos = uint32_t(fp.positions.size());
+        file.write(reinterpret_cast<const char*>(&n_pos), sizeof(uint32_t));
+        file.write(reinterpret_cast<const char*>(fp.positions.data()), n_pos * sizeof(llama_pos));
+        
+        // Write embedding dimension and embedding
+        uint32_t n_embd = uint32_t(fp.embedding.size());
+        file.write(reinterpret_cast<const char*>(&n_embd), sizeof(uint32_t));
+        file.write(reinterpret_cast<const char*>(fp.embedding.data()), n_embd * sizeof(float));
+        
+        // Write tier and turn
+        file.write(reinterpret_cast<const char*>(&fp.tier), sizeof(llama_cache_tier));
+        file.write(reinterpret_cast<const char*>(&fp.turn), sizeof(uint64_t));
+    }
+    
+    return file.good();
+}
+
+bool llama_kv_cache_tiered::load_fingerprints_from_disk(const std::string& path) {
+    std::ifstream file(path, std::ifstream::binary);
+    if (!file) {
+        return false;
+    }
+    
+    // Read number of entries
+    uint32_t n_entries;
+    file.read(reinterpret_cast<char*>(&n_entries), sizeof(uint32_t));
+    
+    // Clear existing fingerprints
+    fingerprints.clear();
+    
+    // Read each fingerprint
+    for (uint32_t i = 0; i < n_entries; i++) {
+        semantic_fingerprint fp;
+        
+        // Read positions
+        uint32_t n_pos;
+        file.read(reinterpret_cast<char*>(&n_pos), sizeof(uint32_t));
+        fp.positions.resize(n_pos);
+        file.read(reinterpret_cast<char*>(fp.positions.data()), n_pos * sizeof(llama_pos));
+        
+        // Read embedding
+        uint32_t n_embd;
+        file.read(reinterpret_cast<char*>(&n_embd), sizeof(uint32_t));
+        fp.embedding.resize(n_embd);
+        file.read(reinterpret_cast<char*>(fp.embedding.data()), n_embd * sizeof(float));
+        
+        // Read tier and turn
+        file.read(reinterpret_cast<char*>(&fp.tier), sizeof(llama_cache_tier));
+        file.read(reinterpret_cast<char*>(&fp.turn), sizeof(uint64_t));
+        
+        fingerprints.push_back(fp);
+    }
+    
+    return file.good();
 }
 
 std::string llama_kv_cache_tiered::get_ssd_file_path(llama_pos pos) const {

--- a/src/llama-kv-cache-tiered.h
+++ b/src/llama-kv-cache-tiered.h
@@ -1,0 +1,253 @@
+#pragma once
+
+#include "llama.h"
+#include "llama-kv-cache.h"
+#include "llama-eviction-policy.h"
+
+#include <vector>
+#include <string>
+#include <memory>
+#include <fstream>
+#include <mutex>
+#include <chrono>
+#include <unordered_map>
+
+#ifdef GGML_USE_HIP
+#include <hip/hip_runtime.h>
+#endif
+
+// Tier types for KV cache
+enum llama_cache_tier {
+    TIER_HOT,   // VRAM - currently used context
+    TIER_WARM,  // RAM - recently used context
+    TIER_COLD   // SSD - less frequently accessed context
+};
+
+// Compression types for cold tier storage
+enum llama_cache_compression {
+    COMPRESSION_NONE,
+    COMPRESSION_INT4,    // 4-bit quantized (4x space reduction)
+    COMPRESSION_INT8,    // 8-bit quantized (2x space reduction)
+    COMPRESSION_LZ4,     // LZ4 compression
+    COMPRESSION_QUANTIZED // Model-native quantization
+};
+
+// Tier configuration
+struct llama_tier_config {
+    float hot_percent;   // Percentage of total context for hot tier (VRAM)
+    float warm_percent;  // Percentage of total context for warm tier (RAM)
+    float cold_percent;  // Percentage of total context for cold tier (SSD)
+
+    uint32_t total_ctx;  // Total context size
+
+    uint32_t hot_capacity() const { return uint32_t(total_ctx * hot_percent / 100.0f); }
+    uint32_t warm_capacity() const { return uint32_t(total_ctx * warm_percent / 100.0f); }
+    uint32_t cold_capacity() const { return uint32_t(total_ctx * cold_percent / 100.0f); }
+
+    // Default configuration: 25% hot, 25% warm, 50% cold
+    static llama_tier_config default_config(uint32_t total_ctx) {
+        return {25.0f, 25.0f, 50.0f, total_ctx};
+    }
+};
+
+// SSD storage format for cold tier
+struct llama_ssd_storage_format {
+    // Magic header for validation
+    static constexpr uint32_t MAGIC = 0x4B565443; // "KVTC"
+    static constexpr uint32_t VERSION = 1;
+
+    // File header structure
+    struct file_header {
+        uint32_t magic;
+        uint32_t version;
+        uint32_t n_layers;
+        uint32_t n_embd_k;
+        uint32_t n_embd_v;
+        uint32_t n_tokens;
+        uint32_t compression_type;
+        uint32_t layer_offset;  // Starting token position for this layer
+        float attention_threshold;
+        uint64_t index_offset;  // Offset to index section
+        uint32_t index_size;    // Size of index in bytes
+    };
+
+    // Layer index entry for quick lookup
+    struct layer_index_entry {
+        uint32_t layer;
+        uint32_t n_tokens;
+        uint64_t file_offset;  // Byte offset in file
+        uint32_t data_size;    // Size of layer data in bytes
+    };
+
+    // Token range for a layer
+    struct token_range {
+        llama_pos start;
+        llama_pos end;
+        uint32_t n_tokens;
+    };
+
+    // Write KV cache to SSD
+    bool write(const std::string& path,
+               const float* k_data,
+               const float* v_data,
+               uint32_t n_tokens,
+               uint32_t n_layers,
+               uint32_t n_embd_k,
+               uint32_t n_embd_v,
+               llama_cache_compression compression = COMPRESSION_INT4);
+
+    // Read KV cache from SSD
+    bool read(const std::string& path,
+              float* k_data,
+              float* v_data,
+              uint32_t n_tokens,
+              uint32_t n_layers,
+              uint32_t n_embd_k,
+              uint32_t n_embd_v);
+
+    // Build index file for fast lookup
+    bool build_index(const std::string& index_path,
+                      const std::string& data_path,
+                      uint32_t n_layers);
+
+    // Load index from file
+    bool load_index(const std::string& index_path);
+
+    // Save index to file
+    bool save_index(const std::string& index_path);
+
+    // Get layer data offset from index
+    uint64_t get_layer_offset(uint32_t layer) const;
+
+    // Check if layer is in index
+    bool has_layer(uint32_t layer) const;
+
+private:
+    // Layer index for fast lookup
+    std::vector<layer_index_entry> layer_index;
+
+    // Helper for quantization
+    std::vector<uint8_t> quantize_int4(const float* data, uint32_t n_elements);
+    std::vector<uint8_t> quantize_int8(const float* data, uint32_t n_elements);
+    bool dequantize_int4(const uint8_t* data, float* out, uint32_t n_elements);
+    bool dequantize_int8(const uint8_t* data, float* out, uint32_t n_elements);
+};
+
+// Tier statistics for monitoring
+struct llama_tier_stats {
+    uint32_t hot_tokens;
+    uint32_t warm_tokens;
+    uint32_t cold_tokens;
+    uint64_t eviction_count;
+    uint64_t cache_hits;
+    uint64_t cache_misses;
+    double total_migration_latency_us;
+
+    void reset() {
+        hot_tokens = 0;
+        warm_tokens = 0;
+        cold_tokens = 0;
+        eviction_count = 0;
+        cache_hits = 0;
+        cache_misses = 0;
+        total_migration_latency_us = 0.0;
+    }
+
+    double get_hit_rate() const {
+        uint64_t total = cache_hits + cache_misses;
+        return total > 0 ? double(cache_hits) / total : 0.0;
+    }
+};
+
+// Main tiered cache class
+class llama_kv_cache_tiered {
+public:
+    // Constructor
+    llama_kv_cache_tiered(
+        const llama_model& model,
+        const llama_tier_config& config,
+        const std::string& ssd_path,
+        llama_eviction_policy eviction_policy = HYBRID,
+        llama_cache_compression compression = COMPRESSION_INT4,
+        float attention_threshold = 0.1f);
+
+    // Destructor
+    ~llama_kv_cache_tiered();
+
+    // Tier management
+    bool init();
+    bool resize(uint32_t new_total_ctx);
+    bool set_eviction_policy(llama_eviction_policy policy);
+    bool set_attention_threshold(float threshold);
+
+    // Eviction interface
+    bool evict_tokens(uint32_t n_tokens_to_evict, llama_cache_tier from_tier);
+    
+    // Migration with tensor handles - requires actual KV cache tensor pointers
+    bool migrate_tokens(const std::vector<llama_pos>& positions,
+                        llama_cache_tier from_tier,
+                        llama_cache_tier to_tier,
+                        const ggml_tensor* k_tensor = nullptr,
+                        const ggml_tensor* v_tensor = nullptr);
+
+    // Migration optimization
+    bool batch_migrate_tokens(const std::vector<llama_pos>& positions,
+                               llama_cache_tier from_tier,
+                               llama_cache_tier to_tier,
+                               const ggml_tensor* k_tensor = nullptr,
+                               const ggml_tensor* v_tensor = nullptr);
+    
+    bool prefetch_tokens(const std::vector<llama_pos>& positions,
+                        llama_cache_tier target_tier);
+
+    // Token access
+    bool contains_token(llama_pos pos) const;
+    bool load_token(llama_pos pos, llama_cache_tier target_tier);
+
+    // Statistics
+    llama_tier_stats get_stats() const;
+    void reset_stats();
+
+    // Configuration getters
+    const llama_tier_config& get_config() const { return config; }
+    llama_eviction_policy get_eviction_policy() const { return eviction_policy; }
+    float get_attention_threshold() const { return attention_threshold; }
+
+private:
+    // Tier capacities
+    llama_tier_config config;
+
+    // Eviction policy
+    llama_eviction_policy eviction_policy;
+
+    // SSD storage path
+    std::string ssd_path;
+
+    // Compression type for cold tier
+    llama_cache_compression compression;
+
+    // Attention threshold for eviction
+    float attention_threshold;
+
+    // Token metadata store
+    llama_token_metadata_store token_metadata;
+
+    // Statistics
+    llama_tier_stats stats;
+
+    // Thread safety
+    mutable std::mutex mutex;
+
+    // KV cache tensor handles for actual data movement
+    // These point to the underlying ggml_tensor objects containing K and V data
+    const ggml_tensor* k_tensor = nullptr;
+    const ggml_tensor* v_tensor = nullptr;
+
+    // Helper methods
+    std::string get_ssd_file_path(llama_pos pos) const;
+    bool save_to_ssd(const std::vector<llama_pos>& positions, const ggml_tensor* k_tensor, const ggml_tensor* v_tensor, bool is_device_data = false);
+    bool load_from_ssd(const std::vector<llama_pos>& positions, ggml_tensor* k_tensor, ggml_tensor* v_tensor, bool to_device = false);
+    
+    // Tier capacity getters
+    uint32_t get_tier_capacity(llama_cache_tier tier) const;
+};

--- a/src/llama-kv-cache-tiered.h
+++ b/src/llama-kv-cache-tiered.h
@@ -23,6 +23,14 @@ enum llama_cache_tier {
     TIER_COLD   // SSD - less frequently accessed context
 };
 
+// Semantic fingerprint for KV cache tokens
+struct semantic_fingerprint {
+    std::vector<llama_pos> positions;  // token positions this covers
+    std::vector<float>     embedding;  // normalized embedding vector
+    llama_cache_tier       tier;       // TIER_WARM or TIER_COLD
+    uint64_t               turn;       // conversation turn when evicted
+};
+
 // Compression types for cold tier storage
 enum llama_cache_compression {
     COMPRESSION_NONE,
@@ -145,6 +153,8 @@ struct llama_tier_stats {
     uint64_t cache_hits;
     uint64_t cache_misses;
     double total_migration_latency_us;
+    uint32_t semantic_prefetch_hits = 0;
+    uint32_t semantic_eviction_saves = 0;
 
     void reset() {
         hot_tokens = 0;
@@ -154,6 +164,8 @@ struct llama_tier_stats {
         cache_hits = 0;
         cache_misses = 0;
         total_migration_latency_us = 0.0;
+        semantic_prefetch_hits = 0;
+        semantic_eviction_saves = 0;
     }
 
     double get_hit_rate() const {
@@ -211,6 +223,25 @@ public:
     bool contains_token(llama_pos pos) const;
     bool load_token(llama_pos pos, llama_cache_tier target_tier);
 
+    // Prefetch hint for semantic similarity
+    struct PrefetchHint {
+        std::vector<llama_pos> positions;
+        float                  score;
+        llama_cache_tier       current_tier;
+    };
+
+    // Fingerprint management
+    void add_fingerprint(const std::vector<llama_pos>& positions,
+                         const std::vector<float>& embedding,
+                         llama_cache_tier tier);
+    bool save_fingerprints_to_disk(const std::string& path);
+    bool load_fingerprints_from_disk(const std::string& path);
+
+    // Semantic similarity scoring
+    std::vector<PrefetchHint> score_fingerprints(
+        const std::vector<float>& query_emb, int top_k, float threshold) const;
+    void set_current_query_embedding(const std::vector<float>& emb);
+
     // Statistics
     llama_tier_stats get_stats() const;
     void reset_stats();
@@ -241,6 +272,13 @@ private:
 
     // Statistics
     llama_tier_stats stats;
+
+    // Semantic fingerprints for evicted tokens
+    std::vector<semantic_fingerprint> fingerprints;
+    uint64_t fingerprint_turn = 0;
+
+    // Current query embedding for semantic eviction weighting
+    std::vector<float> current_query_emb;
 
     // Thread safety
     mutable std::mutex mutex;

--- a/src/llama-kv-cache-tiered.h
+++ b/src/llama-kv-cache-tiered.h
@@ -182,7 +182,11 @@ public:
     bool resize(uint32_t new_total_ctx);
     bool set_eviction_policy(llama_eviction_policy policy);
     bool set_attention_threshold(float threshold);
+#ifdef GGML_USE_HIP
     void set_warm_elem_bytes(size_t n) { warm_elem_bytes = n; }
+#else
+    void set_warm_elem_bytes(size_t) {}
+#endif
 
     // Eviction interface
     bool evict_tokens(uint32_t n_tokens_to_evict, llama_cache_tier from_tier);

--- a/src/llama-kv-cache-tiered.h
+++ b/src/llama-kv-cache-tiered.h
@@ -44,6 +44,9 @@ struct llama_tier_config {
     uint32_t warm_capacity() const { return uint32_t(total_ctx * warm_percent / 100.0f); }
     uint32_t cold_capacity() const { return uint32_t(total_ctx * cold_percent / 100.0f); }
 
+    // HIP device index for warm tier (-1 = RAM/SSD fallback, 1 = 6900XT)
+    int warm_device = -1;
+
     // Default configuration: 25% hot, 25% warm, 50% cold
     static llama_tier_config default_config(uint32_t total_ctx) {
         return {25.0f, 25.0f, 50.0f, total_ctx};
@@ -179,6 +182,7 @@ public:
     bool resize(uint32_t new_total_ctx);
     bool set_eviction_policy(llama_eviction_policy policy);
     bool set_attention_threshold(float threshold);
+    void set_warm_elem_bytes(size_t n) { warm_elem_bytes = n; }
 
     // Eviction interface
     bool evict_tokens(uint32_t n_tokens_to_evict, llama_cache_tier from_tier);
@@ -242,6 +246,21 @@ private:
     // These point to the underlying ggml_tensor objects containing K and V data
     const ggml_tensor* k_tensor = nullptr;
     const ggml_tensor* v_tensor = nullptr;
+
+#ifdef GGML_USE_HIP
+    // 6900XT warm tier: device buffers on warm_device
+    void * warm_k_dev = nullptr;     // hipMalloc'd on warm_device
+    void * warm_v_dev = nullptr;
+    size_t warm_dev_capacity = 0;    // max tokens in warm device buffer
+    size_t warm_elem_bytes  = 0;     // bytes per token per layer for K or V
+    struct WarmSlot { bool occupied = false; llama_pos pos = -1; };
+    std::vector<WarmSlot>                warm_slots;
+    std::unordered_map<llama_pos, int>   warm_pos_to_slot;
+    int  warm_alloc_slot();
+    void warm_free_slot(llama_pos pos);
+    bool warm_copy_to_device(int slot, const void * k_host, const void * v_host, size_t nbytes);
+    bool warm_copy_from_device(int slot, void * k_host, void * v_host, size_t nbytes);
+#endif
 
     // Helper methods
     std::string get_ssd_file_path(llama_pos pos) const;

--- a/src/llama-kv-cache-tiered.h
+++ b/src/llama-kv-cache-tiered.h
@@ -182,14 +182,13 @@ public:
     bool resize(uint32_t new_total_ctx);
     bool set_eviction_policy(llama_eviction_policy policy);
     bool set_attention_threshold(float threshold);
-#ifdef GGML_USE_HIP
-    void set_warm_elem_bytes(size_t n) { warm_elem_bytes = n; }
-#else
-    void set_warm_elem_bytes(size_t) {}
-#endif
+    // Wire real KV layer tensors for actual data movement
+    void set_kv_layers_from_cache(llama_kv_cache * cache);
 
     // Eviction interface
     bool evict_tokens(uint32_t n_tokens_to_evict, llama_cache_tier from_tier);
+    // Pre-register hot positions 0..n_hot-1 so eviction candidates are available
+    void track_hot_range(uint32_t n_hot);
     
     // Migration with tensor handles - requires actual KV cache tensor pointers
     bool migrate_tokens(const std::vector<llama_pos>& positions,
@@ -246,24 +245,39 @@ private:
     // Thread safety
     mutable std::mutex mutex;
 
-    // KV cache tensor handles for actual data movement
-    // These point to the underlying ggml_tensor objects containing K and V data
-    const ggml_tensor* k_tensor = nullptr;
-    const ggml_tensor* v_tensor = nullptr;
-
+    // Per-layer KV tensor info — populated by set_kv_layers_from_cache()
+    // K layout: [n_embd_k_gqa, kv_size, n_stream] — token p is contiguous at row p
+    // V layout: [n_embd_v_gqa, kv_size, n_stream] — when v_trans=true, token p's
+    //   element j is at flat index (j*kv_size + p), requiring scatter/gather
+    struct TieredKVLayer {
+        ggml_tensor * k     = nullptr;   // raw K tensor in VRAM (or host)
+        ggml_tensor * v     = nullptr;   // raw V tensor in VRAM (or host)
+        bool v_trans        = false;     // true = V stored transposed (default)
+        int64_t kv_size     = 0;         // n_ctx_max (= k->ne[1])
+        size_t k_bytes      = 0;         // bytes per token for K (contiguous row)
+        size_t v_bytes      = 0;         // bytes per token for V (de-transposed)
+        uint8_t * warm_k    = nullptr;   // warm_slots * k_bytes, host RAM
+        uint8_t * warm_v    = nullptr;   // warm_slots * v_bytes, host RAM (de-transposed)
 #ifdef GGML_USE_HIP
-    // 6900XT warm tier: device buffers on warm_device
-    void * warm_k_dev = nullptr;     // hipMalloc'd on warm_device
-    void * warm_v_dev = nullptr;
-    size_t warm_dev_capacity = 0;    // max tokens in warm device buffer
-    size_t warm_elem_bytes  = 0;     // bytes per token per layer for K or V
+        void * warm_k_dev   = nullptr;   // optional: device (eGPU) warm K buffer
+        void * warm_v_dev   = nullptr;   // optional: device (eGPU) warm V buffer
+#endif
+    };
+    std::vector<TieredKVLayer> kv_layers;
+
+    // Warm slot occupancy (shared across all layers)
     struct WarmSlot { bool occupied = false; llama_pos pos = -1; };
-    std::vector<WarmSlot>                warm_slots;
-    std::unordered_map<llama_pos, int>   warm_pos_to_slot;
+    std::vector<WarmSlot>              warm_slots;
+    std::unordered_map<llama_pos, int> warm_pos_to_slot;
     int  warm_alloc_slot();
     void warm_free_slot(llama_pos pos);
-    bool warm_copy_to_device(int slot, const void * k_host, const void * v_host, size_t nbytes);
-    bool warm_copy_from_device(int slot, void * k_host, void * v_host, size_t nbytes);
+
+    // Per-layer warm copy helpers: VRAM ↔ RAM (or VRAM ↔ device)
+    bool warm_copy_to_host(uint32_t il, int slot, llama_pos pos);
+    bool warm_copy_from_host(uint32_t il, int slot, llama_pos pos);
+#ifdef GGML_USE_HIP
+    bool warm_copy_to_dev(uint32_t il, int slot, llama_pos pos);
+    bool warm_copy_from_dev(uint32_t il, int slot, llama_pos pos);
 #endif
 
     // Helper methods

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -174,6 +174,12 @@ public:
     // TurboQuant InnerQ: per-channel scale_inv for Q/V equalization
     ggml_tensor * get_turbo_innerq_scale_inv() const { return turbo_innerq_scale_inv; }
 
+    // Raw layer tensor access for tiered KV cache data movement
+    ggml_tensor * get_layer_k_raw(uint32_t layer_idx) const { return layers.at(layer_idx).k; }
+    ggml_tensor * get_layer_v_raw(uint32_t layer_idx) const { return layers.at(layer_idx).v; }
+    uint32_t      get_num_kv_layers() const { return (uint32_t)layers.size(); }
+    bool          is_v_transposed()   const { return v_trans; }
+
     // store k_cur and v_cur in the cache based on the provided head location
     ggml_tensor * cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo) const;
     ggml_tensor * cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il, const slot_info & sinfo) const;

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1533,8 +1533,7 @@ bool llama_model_loader::load_all_data(
                 for (size_t i = 0; i < host_ptrs.size(); i++)
                     io_iovs[i] = { host_ptrs[i], buffer_size };
                 if (!io_reader->register_buffers(io_iovs.data(), (int)io_iovs.size()))
-                    io_reader.reset();
-                else
+                    LLAMA_LOG_WARN("%s: io_uring buffer registration failed, continuing without fixed buffers\n", __func__);
                     LLAMA_LOG_DEBUG("%s: io_uring reader active\n", __func__);
             } else {
                 io_reader.reset();

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1577,6 +1577,19 @@ bool llama_model_loader::load_all_data(
     }
 #endif
 
+    // Phase 2: Collect weight tensor info for the weight pager
+    // This is done before the main loading loop to record file offsets
+    for (struct ggml_tensor * cur = ggml_get_first_tensor(ctx); cur != NULL; cur = ggml_get_next_tensor(ctx, cur)) {
+        const auto * weight = get_weight(ggml_get_name(cur));
+        if (weight == nullptr) {
+            // this can happen with split experts models
+            continue;
+        }
+
+
+    }
+
+    // Reset to first tensor for main loading loop
     for (struct ggml_tensor * cur = ggml_get_first_tensor(ctx); cur != NULL; cur = ggml_get_next_tensor(ctx, cur)) {
         const auto * weight = get_weight(ggml_get_name(cur));
         if (weight == nullptr) {

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1,6 +1,10 @@
 #include "llama-model-loader.h"
 #include "llama-io-uring.h"
 
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+#include <hip/hip_runtime.h>
+#endif
+
 #include "ggml-alloc.h"
 #include "ggml.h"
 #include "gguf.h"
@@ -1434,6 +1438,9 @@ bool llama_model_loader::load_all_data(
     std::vector<ggml_backend_buffer_t> host_buffers;
     std::vector<ggml_backend_event_t> events;
     std::vector<void *> host_ptrs;
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    std::vector<void *> sam_ptrs; // fine-grained VRAM staging for SAM direct path
+#endif
     size_t buffer_idx = 0; // buffer to use for async loads
 
 #ifdef LLAMA_HAVE_IO_URING
@@ -1482,8 +1489,36 @@ bool llama_model_loader::load_all_data(
             return nullptr;
         }
 
-        // If the backend is supported, create pinned memory buffers and events for synchronisation.
+        // If the backend is supported, create staging buffers and events for synchronisation.
+        // With --direct-io on ROCm+SAM: allocate fine-grained VRAM so io_uring writes go
+        // NVMe -> BAR1 -> VRAM directly, bypassing CPU RAM entirely.
+        const bool use_sam_staging = use_direct_io &&
+            (strncmp(ggml_backend_dev_name(dev), "ROCm", 4) == 0);
         for (size_t idx = 0; idx < n_buffers; ++idx) {
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+            if (use_sam_staging) {
+                void * sam_ptr = nullptr;
+                hipError_t herr = hipExtMallocWithFlags(&sam_ptr, buffer_size, hipDeviceMallocFinegrained);
+                if (herr != hipSuccess || !sam_ptr) {
+                    LLAMA_LOG_WARN("%s: hipExtMallocWithFlags failed (%s), falling back to pinned host\n",
+                        func, hipGetErrorString(herr));
+                    // fall through to normal host alloc below
+                } else {
+                    sam_ptrs.emplace_back(sam_ptr);
+                    host_ptrs.emplace_back(sam_ptr);
+                    auto * event = ggml_backend_event_new(dev);
+                    if (!event) {
+                        LLAMA_LOG_DEBUG("%s: failed to create event for SAM staging\n", func);
+                        hipFree(sam_ptr);
+                        sam_ptrs.pop_back();
+                        host_ptrs.pop_back();
+                        return nullptr;
+                    }
+                    events.emplace_back(event);
+                    continue;
+                }
+            }
+#endif
             auto * buf = ggml_backend_buft_alloc_buffer(host_buft, buffer_size);
 
             if (!buf) {
@@ -1682,6 +1717,11 @@ bool llama_model_loader::load_all_data(
         ggml_backend_event_synchronize(event);
         ggml_backend_event_free(event);
     }
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    for (auto * ptr : sam_ptrs) {
+        hipFree(ptr);
+    }
+#endif
     for (auto * buf : host_buffers) {
         ggml_backend_buffer_free(buf);
     }

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1,4 +1,5 @@
 #include "llama-model-loader.h"
+#include "llama-io-uring.h"
 
 #include "ggml-alloc.h"
 #include "ggml.h"
@@ -1434,6 +1435,12 @@ bool llama_model_loader::load_all_data(
     std::vector<ggml_backend_event_t> events;
     std::vector<void *> host_ptrs;
     size_t buffer_idx = 0; // buffer to use for async loads
+
+#ifdef LLAMA_HAVE_IO_URING
+    // io_uring reader: pre-submit NVMe reads so they overlap GPU DMA uploads.
+    std::unique_ptr<llama_io_uring> io_reader;
+    std::vector<struct iovec> io_iovs;
+#endif
     ggml_backend_t upload_backend = [&](const char * func) -> ggml_backend_t {
         if (use_mmap || check_tensors) {
             return nullptr;
@@ -1515,6 +1522,27 @@ bool llama_model_loader::load_all_data(
             ggml_backend_name(upload_backend));
     }
 
+#ifdef LLAMA_HAVE_IO_URING
+    if (upload_backend && !files.empty()) {
+        int fd = files.at(0)->file_id();
+        if (fd >= 0) {
+            io_reader = std::make_unique<llama_io_uring>(fd);
+            if (io_reader->valid()) {
+                // Register all pinned staging buffers for zero-copy DMA
+                io_iovs.resize(host_ptrs.size());
+                for (size_t i = 0; i < host_ptrs.size(); i++)
+                    io_iovs[i] = { host_ptrs[i], buffer_size };
+                if (!io_reader->register_buffers(io_iovs.data(), (int)io_iovs.size()))
+                    io_reader.reset();
+                else
+                    LLAMA_LOG_DEBUG("%s: io_uring reader active\n", __func__);
+            } else {
+                io_reader.reset();
+            }
+        }
+    }
+#endif
+
     for (struct ggml_tensor * cur = ggml_get_first_tensor(ctx); cur != NULL; cur = ggml_get_next_tensor(ctx, cur)) {
         const auto * weight = get_weight(ggml_get_name(cur));
         if (weight == nullptr) {
@@ -1595,6 +1623,18 @@ bool llama_model_loader::load_all_data(
                         ggml_backend_event_synchronize(events[buffer_idx]);
 
                         // Read aligned chunk from file
+#ifdef LLAMA_HAVE_IO_URING
+                        if (io_reader && io_reader->valid()) {
+                            io_reader->submit_read((int)buffer_idx,
+                                reinterpret_cast<void *>(ptr_dest_aligned),
+                                read_size,
+                                aligned_offset + bytes_read,
+                                buffer_idx);
+                            io_reader->submit();
+                            int nr = 0;
+                            io_reader->wait_one(&nr);
+                        } else
+#endif
                         file->read_raw_unsafe(reinterpret_cast<void *>(ptr_dest_aligned), read_size);
 
                         // Calculate actual data portion (excluding alignment padding)

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -31,9 +31,10 @@ const char * llama_file_version_name(llama_fver version);
 
 // Information about a weight tensor for the weight pager
 struct llama_weight_page_info {
-    std::string name;   // tensor name
-    size_t      offset; // file offset in GGUF
-    size_t      size;   // tensor size in bytes
+    std::string name;     // tensor name
+    uint16_t    file_idx; // source file index (for split GGUFs)
+    size_t      offset;   // file offset in GGUF
+    size_t      size;     // tensor size in bytes
 };
 
 struct llama_model_loader {

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -6,6 +6,7 @@
 #include "llama-arch.h"
 #include "llama-hparams.h"
 #include "llama-mmap.h"
+#include "llama-weight-pager.h"
 
 #include "ggml-cpp.h"
 
@@ -27,6 +28,13 @@ enum llama_fver {
 };
 
 const char * llama_file_version_name(llama_fver version);
+
+// Information about a weight tensor for the weight pager
+struct llama_weight_page_info {
+    std::string name;   // tensor name
+    size_t      offset; // file offset in GGUF
+    size_t      size;   // tensor size in bytes
+};
 
 struct llama_model_loader {
     // Holds information on a model weight
@@ -89,6 +97,9 @@ struct llama_model_loader {
     std::map<std::string, llama_tensor_weight, weight_name_comparer> weights_map;
     std::unordered_map<std::string, llama_model_kv_override> kv_overrides;
     const llama_model_tensor_buft_override * tensor_buft_overrides;
+
+    // weight pager info (Phase 2)
+    std::vector<llama_weight_page_info> weight_page_infos;
 
     gguf_context_ptr metadata_ptr;
     struct gguf_context * metadata; // either metadata_ptr.get() or externally set

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -9146,7 +9146,7 @@ llama_model_params llama_model_default_params() {
         /*.no_alloc                    =*/ false,
         /*.weight_paging_enabled       =*/ false,
         /*.weight_paging_slots         =*/ -1,
-        /*.weight_paging_prefetch      =*/ true,
+        /*.weight_paging_prefetch      =*/ false,
     };
 
     return result;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -7987,10 +7987,20 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
             }
         } else {
             ggml_backend_buffer_t buf;
-            if (ml.no_alloc) {
+            if (ml.no_alloc || params.weight_paging_enabled) {
                 buf = ggml_backend_buft_alloc_buffer(buft, /*size =*/ 0); // dummy buffer
+                // Only set the dummy buffer on non-weight tensors.
+                // Weight tensors must have buffer == NULL and data == NULL so that
+                // ggml_gallocr_alloc_graph skips allocation for them.
+                // The weight pager callback will set the correct VRAM slot before each op.
                 for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
-                    t->buffer = buf; // set dummy buffer for weights so that the backend scheduler won't try to allocate them
+                    if (params.weight_paging_enabled && ml.get_weight(ggml_get_name(t))) {
+                        // Skip weight tensors - they will be handled by the weight pager
+                        // Leave buffer == NULL and data == NULL
+                        continue;
+                    }
+                    // Set dummy buffer on non-weight tensors (RoPE freqs, positional embeddings, etc.)
+                    t->buffer = buf;
                 }
             } else {
                 buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx, buft); // real buffer
@@ -8045,14 +8055,36 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
         }
     }
 
-    if (ml.no_alloc) {
+    if (ml.no_alloc && !params.weight_paging_enabled) {
         return true;
     }
 
-    // load tensor data
-    for (auto & [ctx, buf_map] : ctx_buf_maps) {
-        if (!ml.load_all_data(ctx, buf_map, use_mlock ? &pimpl->mlock_mmaps : NULL, params.progress_callback, params.progress_callback_user_data)) {
-            return false;
+    // Populate weight page info for the pager before load_all_data is conditionally skipped
+    if (params.weight_paging_enabled) {
+        for (auto & [ctx, buf_map] : ctx_buf_maps) {
+            for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+                const auto * weight = ml.get_weight(ggml_get_name(t));
+                if (!weight) { continue; }
+                llama_weight_page_info info;
+                info.name     = ggml_get_name(t);
+                info.file_idx = weight->idx;
+                info.offset   = weight->offs;
+                info.size     = ggml_nbytes(t);
+                ml.weight_page_infos.push_back(info);
+                // Collect the actual model tensor pointer for the weight pager
+                if (weight_pager) {
+                    weight_pager->weight_tensor_ptrs.push_back(t);
+                }
+            }
+        }
+    }
+
+    // load tensor data (skip when weight paging is enabled — weights are paged in on-demand)
+    if (!params.weight_paging_enabled) {
+        for (auto & [ctx, buf_map] : ctx_buf_maps) {
+            if (!ml.load_all_data(ctx, buf_map, use_mlock ? &pimpl->mlock_mmaps : NULL, params.progress_callback, params.progress_callback_user_data)) {
+                return false;
+            }
         }
     }
 
@@ -9112,6 +9144,9 @@ llama_model_params llama_model_default_params() {
         /*.use_extra_bufts             =*/ true,
         /*.no_host                     =*/ false,
         /*.no_alloc                    =*/ false,
+        /*.weight_paging_enabled       =*/ false,
+        /*.weight_paging_slots         =*/ -1,
+        /*.weight_paging_prefetch      =*/ true,
     };
 
     return result;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -6,6 +6,7 @@
 #include "llama-hparams.h"
 #include "llama-memory.h"
 #include "llama-vocab.h"
+#include "llama-weight-pager.h"
 
 #include <map>
 #include <memory>
@@ -570,6 +571,9 @@ struct llama_model {
 
     // for keeping track of associated LoRA adapters
     std::unordered_set<llama_adapter_lora *> loras;
+
+    // weight paging for NVMe→VRAM demand paging
+    std::unique_ptr<llama_weight_pager> weight_pager;
 
     // statically allocated context for assigning
     struct llama_meta_device_get_split_state_userdata get_split_state_ud;

--- a/src/llama-weight-pager.cpp
+++ b/src/llama-weight-pager.cpp
@@ -1,0 +1,408 @@
+#include "llama-weight-pager.h"
+#include "ggml.h"
+#include "llama-impl.h"
+
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+#include <hip/hip_runtime.h>
+#endif
+#include <algorithm>
+#include <limits>
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+// ============================================================================
+// Weight Pager Eval Callback (Phase 3 + Phase 4)
+// ============================================================================
+
+/// Track the last processed page index for prefetch submission across callbacks
+static int s_last_processed_page = -1;
+
+/// Eval callback for weight pager. Called before each graph node is executed.
+/// Phase 3: Ensures weight tensors are paged in to VRAM before use.
+/// Phase 4: Completes in-flight prefetches and submits prefetch for next layer.
+bool weight_pager_eval_cb(struct ggml_tensor * t, bool ask, void * user_data) {
+    if (ask) {
+        return true; // yes, we want the callback
+    }
+
+    auto * pager = (llama_weight_pager *) user_data;
+    if (!pager) {
+        return true;
+    }
+
+    // Collect page indices for all weight tensors in this tensor's sources
+    std::vector<int> page_indices;
+    for (int i = 0; i < GGML_MAX_SRC; i++) {
+        if (!t->src[i]) {
+            break;
+        }
+
+        struct ggml_tensor * src = t->src[i];
+        if (!src) {
+            continue;
+        }
+
+        const char * tensor_name = ggml_get_name(src);
+        int page_idx = pager->find_page(tensor_name);
+        if (page_idx < 0) {
+            continue; // not a weight tensor tracked by pager
+        }
+
+        page_indices.push_back(page_idx);
+    }
+
+    if (page_indices.empty()) {
+        return true;
+    }
+
+    // Phase 4: Complete any in-flight prefetches for the pages we need
+#ifdef LLAMA_HAVE_IO_URING
+    if (pager->async_prefetch && pager->io_reader != nullptr) {
+        for (int page_idx : page_indices) {
+            pager->complete_prefetch(page_idx);
+        }
+    }
+#endif
+
+    // Phase 3: Ensure each tensor is in VRAM and redirect data pointers
+    for (int page_idx : page_indices) {
+        llama_weight_page & page = pager->pages[page_idx];
+        void * vram = pager->ensure(page.tensor_name);
+        if (vram) {
+            // Redirect tensor data pointer to current VRAM slot
+            // Find the source tensor and update its data pointer
+            for (int i = 0; i < GGML_MAX_SRC; i++) {
+                if (!t->src[i]) {
+                    break;
+                }
+                struct ggml_tensor * src = t->src[i];
+                if (src && strcmp(ggml_get_name(src), page.tensor_name.c_str()) == 0) {
+                    src->data = vram;
+                }
+            }
+        }
+    }
+
+    // Phase 4: Submit prefetch for the next page (pipeline NVMe reads with GPU compute)
+#ifdef LLAMA_HAVE_IO_URING
+    if (pager->async_prefetch && pager->io_reader != nullptr) {
+        // Find the highest page index we just processed
+        int max_page = -1;
+        for (int page_idx : page_indices) {
+            if (page_idx > max_page) {
+                max_page = page_idx;
+            }
+        }
+
+        // Submit prefetch for the next page if it exists
+        if (max_page >= 0 && max_page + 1 < (int)pager->pages.size()) {
+            pager->submit_prefetch(max_page + 1);
+        }
+    }
+#endif
+
+    return true;
+}
+
+// ============================================================================
+// llama_vram_pool implementation
+// ============================================================================
+
+int llama_vram_pool::alloc_slot() {
+    // First, try to find a free slot
+    for (int i = 0; i < n_slots; i++) {
+        if (!used[i]) {
+            used[i] = true;
+            return i;
+        }
+    }
+
+    // All slots are in use - find and evict the LRU slot
+    int lru_idx = 0;
+    uint64_t min_tick = lru_tick[0];
+
+    for (int i = 1; i < n_slots; i++) {
+        if (lru_tick[i] < min_tick) {
+            min_tick = lru_tick[i];
+            lru_idx = i;
+        }
+    }
+
+    // Evict the LRU slot — caller is responsible for updating page state
+    // (slot remains marked used; caller overwrites it)
+    used[lru_idx] = true;
+    return lru_idx;
+}
+
+void llama_vram_pool::free_slot(int idx) {
+    if (idx < 0 || idx >= n_slots) {
+        return;  // invalid index
+    }
+    used[idx] = false;
+}
+
+// ============================================================================
+// llama_weight_pager implementation
+// ============================================================================
+
+void llama_weight_pager::init_pool(size_t slot_size, int n_slots) {
+    if (n_slots <= 0) {
+        return;  // invalid configuration
+    }
+
+    pool.slot_size = slot_size;
+    pool.n_slots = n_slots;
+    pool.used.resize(n_slots, false);
+    pool.lru_tick.resize(n_slots, 0);
+
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    hipError_t err = hipMalloc(&pool.base, (size_t)n_slots * slot_size);
+    if (err != hipSuccess) {
+        LLAMA_LOG_WARN("llama_weight_pager: hipMalloc failed (%s), weight paging disabled\n", hipGetErrorString(err));
+        pool.base = nullptr;
+    }
+#else
+    pool.base = nullptr;
+#endif
+}
+
+void* llama_weight_pager::ensure(const std::string & name) {
+    int page_idx = find_page(name);
+    if (page_idx < 0) {
+        // Tensor not tracked by pager
+        return nullptr;
+    }
+
+    llama_weight_page & page = pages[page_idx];
+
+    // If already in VRAM, update tick and return pointer
+    if (page.slot_idx >= 0 && page.vram_ptr != nullptr) {
+        // Update LRU tick for this page
+        page.last_used = ++tick;
+        // Also update the slot's lru_tick
+        if (page.slot_idx < pool.n_slots) {
+            pool.lru_tick[page.slot_idx] = tick;
+        }
+        return page.vram_ptr;
+    }
+
+    // Not in VRAM - need to page in
+    // Phase 1 stub: page_in() returns nullptr, so we return nullptr
+    // In Phase 2, this will actually load from NVMe
+    page_in(page);
+
+    if (page.vram_ptr != nullptr) {
+        page.last_used = ++tick;
+        if (page.slot_idx >= 0 && page.slot_idx < pool.n_slots) {
+            pool.lru_tick[page.slot_idx] = tick;
+        }
+    }
+
+    return page.vram_ptr;
+}
+
+void llama_weight_pager::evict_lru() {
+    // Find the LRU page that is currently loaded
+    int lru_page_idx = -1;
+    uint64_t min_tick = std::numeric_limits<uint64_t>::max();
+
+    for (size_t i = 0; i < pages.size(); i++) {
+        const llama_weight_page & page = pages[i];
+        if (page.slot_idx >= 0 && page.last_used < min_tick) {
+            min_tick = page.last_used;
+            lru_page_idx = (int)i;
+        }
+    }
+
+    if (lru_page_idx < 0) {
+        return;
+    }
+
+    llama_weight_page & page = pages[lru_page_idx];
+    pool.free_slot(page.slot_idx);
+    page.slot_idx = -1;
+    page.vram_ptr = nullptr;
+}
+
+// When pool.alloc_slot() evicts a slot, we must also clear the page that owned it.
+// Called internally after alloc_slot() returns an in-use slot index.
+static void pager_invalidate_slot(llama_weight_pager * pager, int slot_idx) {
+    for (auto & page : pager->pages) {
+        if (page.slot_idx == slot_idx) {
+            page.slot_idx = -1;
+            page.vram_ptr = nullptr;
+            return;
+        }
+    }
+}
+
+int llama_weight_pager::find_page(const std::string & name) const {
+    auto it = name_to_page.find(name);
+    if (it != name_to_page.end()) {
+        return it->second;
+    }
+    return -1;
+}
+
+void llama_weight_pager::page_in(llama_weight_page & page) {
+    // Phase 2: actual page-in from NVMe to VRAM
+    // Check if we have a valid pool and file descriptor
+    if (!pool.is_valid() || fd < 0) {
+        return;  // cannot page in without pool or fd
+    }
+
+    // Allocate a slot (may evict LRU if full — invalidate the displaced page)
+    int slot = pool.alloc_slot();
+    pager_invalidate_slot(this, slot);
+    void * dst = pool.slot_ptr(slot);
+
+    // Read from file directly into VRAM via pread
+    // For SAM/ReBAR, this goes NVMe → BAR1 → VRAM directly
+    ssize_t n = pread(fd, dst, page.size, page.file_offset);
+    if (n != (ssize_t)page.size) {
+        LLAMA_LOG_WARN("page_in: failed to read tensor (read %zd/%zu bytes)\n", n, page.size);
+        // On failure, free the slot and return
+        pool.free_slot(slot);
+        return;
+    }
+
+    // Update page state
+    page.slot_idx = slot;
+    page.vram_ptr = (uint8_t*)dst;
+    pool.used[slot] = true;
+    pool.lru_tick[slot] = ++tick;
+}
+
+int llama_weight_pager::get_lru_slot() const {
+    if (pool.n_slots <= 0) {
+        return -1;
+    }
+
+    int lru_idx = 0;
+    uint64_t min_tick = pool.lru_tick[0];
+
+    for (int i = 1; i < pool.n_slots; i++) {
+        if (pool.lru_tick[i] < min_tick) {
+            min_tick = pool.lru_tick[i];
+            lru_idx = i;
+        }
+    }
+
+    return lru_idx;
+}
+
+// ============================================================================
+// Async Prefetch via io_uring (Phase 4)
+// ============================================================================
+
+#ifdef LLAMA_HAVE_IO_URING
+
+#include "llama-io-uring.h"
+
+bool llama_weight_pager::init_io_uring(int queue_depth) {
+    if (fd < 0) {
+        return false;
+    }
+    io_reader = new llama_io_uring(fd, queue_depth);
+    if (!io_reader->valid()) {
+        delete io_reader;
+        io_reader = nullptr;
+        return false;
+    }
+    return true;
+}
+
+void llama_weight_pager::submit_prefetch(int page_idx) {
+    if (!io_reader || !async_prefetch) {
+        return;
+    }
+
+    if (page_idx < 0 || page_idx >= (int)pages.size()) {
+        return;
+    }
+
+    auto & page = pages[page_idx];
+    if (page.slot_idx >= 0) {
+        return; // already in VRAM
+    }
+
+    // Check if already in-flight
+    if (in_flight.count(page_idx)) {
+        return; // already being prefetched
+    }
+
+    // Allocate a slot (may evict LRU if needed — invalidate the displaced page)
+    int slot = pool.alloc_slot();
+    pager_invalidate_slot(this, slot);
+    void * dst = pool.slot_ptr(slot);
+
+    // Submit async read via io_uring
+    // Use page_idx as user_data to identify completion
+    io_reader->submit_read(0, dst, page.size, page.file_offset, (uint64_t)page_idx);
+
+    in_flight[page_idx] = { page_idx, slot, dst };
+}
+
+bool llama_weight_pager::complete_prefetch(int page_idx) {
+    if (page_idx < 0 || page_idx >= (int)pages.size()) {
+        return false;
+    }
+
+    auto & page = pages[page_idx];
+
+    // If already loaded (via ensure or previous prefetch), return true
+    if (page.slot_idx >= 0 && page.vram_ptr != nullptr) {
+        return true;
+    }
+
+    // Check if this page is in-flight
+    auto it = in_flight.find(page_idx);
+    if (it == in_flight.end()) {
+        return false; // not being prefetched
+    }
+
+    // Wait for completion and process all completions
+    bool loaded = false;
+    while (!in_flight.empty()) {
+        uint64_t user_data = io_reader->wait_one(nullptr);
+        if (user_data == UINT64_MAX) {
+            break; // error or timeout
+        }
+
+        int completed_idx = (int)user_data;
+        if (completed_idx < 0 || completed_idx >= (int)pages.size()) {
+            continue; // invalid page index
+        }
+
+        auto & completed_page = pages[completed_idx];
+        auto fit = in_flight.find(completed_idx);
+        if (fit == in_flight.end()) {
+            continue; // already processed
+        }
+
+        auto & req = fit->second;
+
+        // Update page state with the loaded data
+        completed_page.slot_idx = req.slot_idx;
+        completed_page.vram_ptr = (uint8_t*)req.dst;
+        pool.used[req.slot_idx] = true;
+        pool.lru_tick[req.slot_idx] = ++tick;
+
+        in_flight.erase(fit);
+        if (completed_idx == page_idx) {
+            loaded = true;
+        }
+    }
+
+    return loaded;
+}
+
+void llama_weight_pager::drain_prefetches() {
+    while (!in_flight.empty()) {
+        io_reader->wait_one(nullptr);
+    }
+}
+
+#endif // LLAMA_HAVE_IO_URING

--- a/src/llama-weight-pager.cpp
+++ b/src/llama-weight-pager.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <cstring>
 #include <fcntl.h>
+#include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
 
@@ -32,25 +33,41 @@ bool weight_pager_eval_cb(struct ggml_tensor * t, bool ask, void * user_data) {
         return true;
     }
 
-    // Collect page indices for all weight tensors in this tensor's sources
+    // DIAGNOSTIC: Log callback invocation
+    LLAMA_LOG_INFO("weight_pager_eval_cb: tensor=%s ask=%s\n",
+                   ggml_get_name(t), ask ? "true" : "false");
+    LLAMA_LOG_INFO("weight_pager_eval_cb: pager=%p pool.base=%p pool.n_slots=%d\n",
+                   pager, pager->pool.base, pager->pool.n_slots);
+
+    // Collect page indices for all weight tensors in this tensor's sources.
+    // Also detect view tensors of tracked weights (ggml_gallocr_alloc_graph initialises
+    // their data to (char*)1 + view_offs -- garbage -- so we must overwrite it
+    // with the real paged-in VRAM address before every op that uses them).
     std::vector<int> page_indices;
     for (int i = 0; i < GGML_MAX_SRC; i++) {
-        if (!t->src[i]) {
+        struct ggml_tensor * src = t->src[i];
+        if (!src) {
             break;
         }
 
-        struct ggml_tensor * src = t->src[i];
-        if (!src) {
+        // Direct weight tensor match
+        int page_idx = pager->find_page(ggml_get_name(src));
+
+        // View tensor whose source is a tracked weight
+        if (page_idx < 0 && src->view_src != nullptr) {
+            page_idx = pager->find_page(ggml_get_name(src->view_src));
+        }
+
+        if (page_idx < 0) {
             continue;
         }
 
-        const char * tensor_name = ggml_get_name(src);
-        int page_idx = pager->find_page(tensor_name);
-        if (page_idx < 0) {
-            continue; // not a weight tensor tracked by pager
+        // Deduplicate (e.g. two views of the same weight in one op)
+        bool already = false;
+        for (int idx : page_indices) { if (idx == page_idx) { already = true; break; } }
+        if (!already) {
+            page_indices.push_back(page_idx);
         }
-
-        page_indices.push_back(page_idx);
     }
 
     if (page_indices.empty()) {
@@ -66,20 +83,26 @@ bool weight_pager_eval_cb(struct ggml_tensor * t, bool ask, void * user_data) {
     }
 #endif
 
-    // Phase 3: Ensure each tensor is in VRAM and redirect data pointers
+    // Phase 3: Ensure each tensor is in VRAM and redirect data pointers.
+    // Handles both direct weight sources and view tensors of those weights.
     for (int page_idx : page_indices) {
         llama_weight_page & page = pager->pages[page_idx];
         void * vram = pager->ensure(page.tensor_name);
         if (vram) {
-            // Redirect tensor data pointer to current VRAM slot
-            // Find the source tensor and update its data pointer
             for (int i = 0; i < GGML_MAX_SRC; i++) {
-                if (!t->src[i]) {
+                struct ggml_tensor * src = t->src[i];
+                if (!src) {
                     break;
                 }
-                struct ggml_tensor * src = t->src[i];
-                if (src && strcmp(ggml_get_name(src), page.tensor_name.c_str()) == 0) {
+                // Direct weight tensor
+                if (strcmp(ggml_get_name(src), page.tensor_name.c_str()) == 0) {
                     src->data = vram;
+                }
+                // View of this weight: gallocr sets data=(char*)sentinel+view_offs;
+                // overwrite with the real paged-in slot address + offset.
+                else if (src->view_src != nullptr &&
+                         strcmp(ggml_get_name(src->view_src), page.tensor_name.c_str()) == 0) {
+                    src->data = (char *)vram + src->view_offs;
                 }
             }
         }
@@ -147,9 +170,29 @@ void llama_vram_pool::free_slot(int idx) {
 // llama_weight_pager implementation
 // ============================================================================
 
-void llama_weight_pager::init_pool(size_t slot_size, int n_slots) {
+llama_weight_pager::~llama_weight_pager() {
+    for (int fd : fds) {
+        if (fd >= 0) {
+            close(fd);
+        }
+    }
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    if (pool.pinned_staging != nullptr) {
+        hipHostFree(pool.pinned_staging);
+    }
+    if (pool.base != nullptr) {
+        hipFree(pool.base);
+    }
+    if (transfer_stream != nullptr) {
+        hipStreamDestroy((hipStream_t)transfer_stream);
+    }
+#endif
+}
+
+bool llama_weight_pager::init_pool(size_t slot_size, int n_slots) {
     if (n_slots <= 0) {
-        return;  // invalid configuration
+        LLAMA_LOG_WARN("init_pool: invalid n_slots=%d\n", n_slots);
+        return false;
     }
 
     pool.slot_size = slot_size;
@@ -157,14 +200,48 @@ void llama_weight_pager::init_pool(size_t slot_size, int n_slots) {
     pool.used.resize(n_slots, false);
     pool.lru_tick.resize(n_slots, 0);
 
+    LLAMA_LOG_INFO("init_pool: allocating %d slots of %zu bytes each\n", n_slots, slot_size);
+
 #if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    // Allocate the VRAM pool using hipMalloc
     hipError_t err = hipMalloc(&pool.base, (size_t)n_slots * slot_size);
     if (err != hipSuccess) {
-        LLAMA_LOG_WARN("llama_weight_pager: hipMalloc failed (%s), weight paging disabled\n", hipGetErrorString(err));
+        LLAMA_LOG_WARN("llama_weight_pager: hipMalloc failed: %s\n", hipGetErrorString(err));
         pool.base = nullptr;
+        return false;
     }
+
+    // Allocate the pinned host staging buffer
+    err = hipHostMalloc(&pool.pinned_staging, slot_size, hipHostMallocDefault);
+    if (err != hipSuccess) {
+        LLAMA_LOG_WARN("llama_weight_pager: hipHostMalloc for pinned_staging failed: %s\n", hipGetErrorString(err));
+        hipFree(pool.base);
+        pool.base = nullptr;
+        pool.pinned_staging = nullptr;
+        return false;
+    }
+
+    // Create the async transfer stream
+    err = hipStreamCreate((hipStream_t*)&transfer_stream);
+    if (err != hipSuccess) {
+        LLAMA_LOG_WARN("llama_weight_pager: hipStreamCreate failed: %s\n", hipGetErrorString(err));
+        hipHostFree(pool.pinned_staging);
+        hipFree(pool.base);
+        pool.base = nullptr;
+        pool.pinned_staging = nullptr;
+        transfer_stream = nullptr;
+        return false;
+    }
+
+    LLAMA_LOG_INFO("init_pool: allocated pool.base=%p pinned_staging=%p transfer_stream=%p (slot_size=%zu, n_slots=%d)\n",
+                   pool.base, pool.pinned_staging, transfer_stream, slot_size, n_slots);
+    return true;
 #else
+    LLAMA_LOG_WARN("init_pool: HIP not available, falling back\n");
     pool.base = nullptr;
+    pool.pinned_staging = nullptr;
+    transfer_stream = nullptr;
+    return false;
 #endif
 }
 
@@ -176,6 +253,10 @@ void* llama_weight_pager::ensure(const std::string & name) {
     }
 
     llama_weight_page & page = pages[page_idx];
+
+    // DIAGNOSTIC: Log ensure call
+    LLAMA_LOG_INFO("ensure: tensor=%s page_idx=%d slot_idx=%d vram_ptr=%p\n",
+                   name.c_str(), page_idx, page.slot_idx, page.vram_ptr);
 
     // If already in VRAM, update tick and return pointer
     if (page.slot_idx >= 0 && page.vram_ptr != nullptr) {
@@ -191,13 +272,18 @@ void* llama_weight_pager::ensure(const std::string & name) {
     // Not in VRAM - need to page in
     // Phase 1 stub: page_in() returns nullptr, so we return nullptr
     // In Phase 2, this will actually load from NVMe
+    LLAMA_LOG_INFO("ensure: calling page_in for tensor %s\n", name.c_str());
     page_in(page);
+    LLAMA_LOG_INFO("ensure: page_in returned, page.slot_idx=%d page.vram_ptr=%p\n",
+                   page.slot_idx, page.vram_ptr);
 
     if (page.vram_ptr != nullptr) {
         page.last_used = ++tick;
         if (page.slot_idx >= 0 && page.slot_idx < pool.n_slots) {
             pool.lru_tick[page.slot_idx] = tick;
         }
+    } else {
+        LLAMA_LOG_WARN("ensure: page_in returned nullptr for tensor %s\n", name.c_str());
     }
 
     return page.vram_ptr;
@@ -231,6 +317,8 @@ void llama_weight_pager::evict_lru() {
 static void pager_invalidate_slot(llama_weight_pager * pager, int slot_idx) {
     for (auto & page : pager->pages) {
         if (page.slot_idx == slot_idx) {
+            LLAMA_LOG_INFO("pager_invalidate_slot: invalidating slot=%d tensor=%s\n",
+                           slot_idx, page.tensor_name.c_str());
             page.slot_idx = -1;
             page.vram_ptr = nullptr;
             return;
@@ -247,26 +335,54 @@ int llama_weight_pager::find_page(const std::string & name) const {
 }
 
 void llama_weight_pager::page_in(llama_weight_page & page) {
-    // Phase 2: actual page-in from NVMe to VRAM
+    LLAMA_LOG_INFO("page_in: loading tensor %s (file_idx=%u, offset=%zu, size=%zu)\n",
+                   page.tensor_name.c_str(), (unsigned)page.file_idx, page.file_offset, page.size);
+    // Phase 3: two-step path with async stream - NVMe → pinned staging → VRAM
     // Check if we have a valid pool and file descriptor
-    if (!pool.is_valid() || fd < 0) {
-        return;  // cannot page in without pool or fd
+    if (!pool.is_valid() || pool.pinned_staging == nullptr || fds.empty() || fds[0] < 0) {
+        LLAMA_LOG_WARN("page_in: no valid pool or fd (pool.valid=%s pool.pinned_staging=%p fds.empty=%s fds[0]=%d)\n",
+                       pool.is_valid() ? "true" : "false",
+                       pool.pinned_staging,
+                       fds.empty() ? "true" : "false",
+                       fds.empty() ? -1 : fds[0]);
+        return;  // cannot page in without pool, pinned_staging, or fd
     }
 
-    // Allocate a slot (may evict LRU if full — invalidate the displaced page)
+    // Step 1: Read from NVMe into pinned host staging buffer
+    int read_fd = (page.file_idx < (uint16_t)fds.size()) ? fds[page.file_idx] : (fds.empty() ? -1 : fds[0]);
+    LLAMA_LOG_INFO("page_in: pread fd=%d pinned_staging=%p size=%zu offset=%zu\n",
+                   read_fd, pool.pinned_staging, page.size, page.file_offset);
+    ssize_t n = pread(read_fd, pool.pinned_staging, page.size, page.file_offset);
+    LLAMA_LOG_INFO("page_in: pread returned %zd (errno=%d)\n", n, errno);
+    if (n != (ssize_t)page.size) {
+        LLAMA_LOG_WARN("page_in: failed to read tensor (read %zd/%zu bytes)\n", n, page.size);
+        return;
+    }
+
+    // Step 2: Allocate a slot (may evict LRU if full — invalidate the displaced page)
     int slot = pool.alloc_slot();
     pager_invalidate_slot(this, slot);
     void * dst = pool.slot_ptr(slot);
 
-    // Read from file directly into VRAM via pread
-    // For SAM/ReBAR, this goes NVMe → BAR1 → VRAM directly
-    ssize_t n = pread(fd, dst, page.size, page.file_offset);
-    if (n != (ssize_t)page.size) {
-        LLAMA_LOG_WARN("page_in: failed to read tensor (read %zd/%zu bytes)\n", n, page.size);
-        // On failure, free the slot and return
+    // Step 3: Copy from pinned staging to VRAM slot using hipMemcpyAsync on transfer_stream
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    LLAMA_LOG_INFO("page_in: hipMemcpyAsync dst=%p pinned_staging=%p size=%zu stream=%p\n",
+                   dst, pool.pinned_staging, page.size, transfer_stream);
+    hipError_t err = hipMemcpyAsync(dst, pool.pinned_staging, page.size, hipMemcpyHostToDevice, (hipStream_t)transfer_stream);
+    if (err != hipSuccess) {
+        LLAMA_LOG_WARN("page_in: hipMemcpyAsync failed: %s\n", hipGetErrorString(err));
         pool.free_slot(slot);
         return;
     }
+
+    // Synchronize to ensure transfer completes before returning (synchronous case)
+    err = hipStreamSynchronize((hipStream_t)transfer_stream);
+    if (err != hipSuccess) {
+        LLAMA_LOG_WARN("page_in: hipStreamSynchronize failed: %s\n", hipGetErrorString(err));
+        pool.free_slot(slot);
+        return;
+    }
+#endif
 
     // Update page state
     page.slot_idx = slot;
@@ -302,10 +418,10 @@ int llama_weight_pager::get_lru_slot() const {
 #include "llama-io-uring.h"
 
 bool llama_weight_pager::init_io_uring(int queue_depth) {
-    if (fd < 0) {
+    if (fds.empty() || fds[0] < 0) {
         return false;
     }
-    io_reader = new llama_io_uring(fd, queue_depth);
+    io_reader = new llama_io_uring(fds.empty() ? -1 : fds[0], queue_depth);
     if (!io_reader->valid()) {
         delete io_reader;
         io_reader = nullptr;
@@ -338,9 +454,11 @@ void llama_weight_pager::submit_prefetch(int page_idx) {
     pager_invalidate_slot(this, slot);
     void * dst = pool.slot_ptr(slot);
 
-    // Submit async read via io_uring
+    // Submit async read via io_uring to pinned staging buffer
     // Use page_idx as user_data to identify completion
-    io_reader->submit_read(0, dst, page.size, page.file_offset, (uint64_t)page_idx);
+    // The read goes into pinned_staging, not directly into VRAM
+    void * staging_dst = pool.pinned_staging;
+    io_reader->submit_read(0, staging_dst, page.size, page.file_offset, (uint64_t)page_idx);
 
     in_flight[page_idx] = { page_idx, slot, dst };
 }
@@ -383,6 +501,18 @@ bool llama_weight_pager::complete_prefetch(int page_idx) {
         }
 
         auto & req = fit->second;
+
+        // Issue async GPU transfer from pinned_staging to VRAM slot
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+        if (pool.pinned_staging != nullptr && transfer_stream != nullptr) {
+            hipError_t err = hipMemcpyAsync(req.dst, pool.pinned_staging, page.size, hipMemcpyHostToDevice, (hipStream_t)transfer_stream);
+            if (err != hipSuccess) {
+                LLAMA_LOG_WARN("complete_prefetch: hipMemcpyAsync failed: %s\n", hipGetErrorString(err));
+                in_flight.erase(fit);
+                continue;
+            }
+        }
+#endif
 
         // Update page state with the loaded data
         completed_page.slot_idx = req.slot_idx;

--- a/src/llama-weight-pager.cpp
+++ b/src/llama-weight-pager.cpp
@@ -1,4 +1,6 @@
 #include "llama-weight-pager.h"
+#include "ggml-backend.h"
+#include "ggml-cuda.h"
 #include "ggml.h"
 #include "llama-impl.h"
 
@@ -24,20 +26,16 @@ static int s_last_processed_page = -1;
 /// Phase 3: Ensures weight tensors are paged in to VRAM before use.
 /// Phase 4: Completes in-flight prefetches and submits prefetch for next layer.
 bool weight_pager_eval_cb(struct ggml_tensor * t, bool ask, void * user_data) {
-    if (ask) {
-        return true; // yes, we want the callback
+    // ask=true fires before execution — load weights here so they are ready.
+    // ask=false fires after execution — nothing to do, just return.
+    if (!ask) {
+        return true;
     }
 
     auto * pager = (llama_weight_pager *) user_data;
     if (!pager) {
         return true;
     }
-
-    // DIAGNOSTIC: Log callback invocation
-    LLAMA_LOG_INFO("weight_pager_eval_cb: tensor=%s ask=%s\n",
-                   ggml_get_name(t), ask ? "true" : "false");
-    LLAMA_LOG_INFO("weight_pager_eval_cb: pager=%p pool.base=%p pool.n_slots=%d\n",
-                   pager, pager->pool.base, pager->pool.n_slots);
 
     // Collect page indices for all weight tensors in this tensor's sources.
     // Also detect view tensors of tracked weights (ggml_gallocr_alloc_graph initialises
@@ -49,7 +47,6 @@ bool weight_pager_eval_cb(struct ggml_tensor * t, bool ask, void * user_data) {
         if (!src) {
             break;
         }
-
         // Direct weight tensor match
         int page_idx = pager->find_page(ggml_get_name(src));
 
@@ -96,13 +93,15 @@ bool weight_pager_eval_cb(struct ggml_tensor * t, bool ask, void * user_data) {
                 }
                 // Direct weight tensor
                 if (strcmp(ggml_get_name(src), page.tensor_name.c_str()) == 0) {
-                    src->data = vram;
+                    src->data   = vram;
+                    src->buffer = pager->pool.ggml_buf;
                 }
                 // View of this weight: gallocr sets data=(char*)sentinel+view_offs;
                 // overwrite with the real paged-in slot address + offset.
                 else if (src->view_src != nullptr &&
                          strcmp(ggml_get_name(src->view_src), page.tensor_name.c_str()) == 0) {
-                    src->data = (char *)vram + src->view_offs;
+                    src->data   = (char *)vram + src->view_offs;
+                    src->buffer = pager->pool.ggml_buf;
                 }
             }
         }
@@ -180,8 +179,10 @@ llama_weight_pager::~llama_weight_pager() {
     if (pool.pinned_staging != nullptr) {
         hipHostFree(pool.pinned_staging);
     }
-    if (pool.base != nullptr) {
-        hipFree(pool.base);
+    if (pool.ggml_buf != nullptr) {
+        ggml_backend_buffer_free(pool.ggml_buf);
+        pool.ggml_buf = nullptr;
+        pool.base     = nullptr;
     }
     if (transfer_stream != nullptr) {
         hipStreamDestroy((hipStream_t)transfer_stream);
@@ -203,13 +204,18 @@ bool llama_weight_pager::init_pool(size_t slot_size, int n_slots) {
     LLAMA_LOG_INFO("init_pool: allocating %d slots of %zu bytes each\n", n_slots, slot_size);
 
 #if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
-    // Allocate the VRAM pool using hipMalloc
-    hipError_t err = hipMalloc(&pool.base, (size_t)n_slots * slot_size);
-    if (err != hipSuccess) {
-        LLAMA_LOG_WARN("llama_weight_pager: hipMalloc failed: %s\n", hipGetErrorString(err));
+    // Allocate the VRAM pool as a proper ggml CUDA buffer so that
+    // tensor->buffer can be set to a valid CUDA buffer type, which
+    // ggml_cuda_mul_mat checks on every call.
+    ggml_backend_buffer_type_t cuda_buft = ggml_backend_cuda_buffer_type(0);
+    pool.ggml_buf = ggml_backend_buft_alloc_buffer(cuda_buft, (size_t)n_slots * slot_size);
+    if (!pool.ggml_buf) {
+        LLAMA_LOG_WARN("llama_weight_pager: ggml_backend_buft_alloc_buffer failed\n");
         pool.base = nullptr;
         return false;
     }
+    pool.base = ggml_backend_buffer_get_base(pool.ggml_buf);
+    hipError_t err = hipSuccess; // needed for subsequent hipHostMalloc / hipStreamCreate checks
 
     // Allocate the pinned host staging buffer
     err = hipHostMalloc(&pool.pinned_staging, slot_size, hipHostMallocDefault);
@@ -254,10 +260,6 @@ void* llama_weight_pager::ensure(const std::string & name) {
 
     llama_weight_page & page = pages[page_idx];
 
-    // DIAGNOSTIC: Log ensure call
-    LLAMA_LOG_INFO("ensure: tensor=%s page_idx=%d slot_idx=%d vram_ptr=%p\n",
-                   name.c_str(), page_idx, page.slot_idx, page.vram_ptr);
-
     // If already in VRAM, update tick and return pointer
     if (page.slot_idx >= 0 && page.vram_ptr != nullptr) {
         // Update LRU tick for this page
@@ -269,13 +271,8 @@ void* llama_weight_pager::ensure(const std::string & name) {
         return page.vram_ptr;
     }
 
-    // Not in VRAM - need to page in
-    // Phase 1 stub: page_in() returns nullptr, so we return nullptr
-    // In Phase 2, this will actually load from NVMe
-    LLAMA_LOG_INFO("ensure: calling page_in for tensor %s\n", name.c_str());
+    // Not in VRAM — page in from NVMe.
     page_in(page);
-    LLAMA_LOG_INFO("ensure: page_in returned, page.slot_idx=%d page.vram_ptr=%p\n",
-                   page.slot_idx, page.vram_ptr);
 
     if (page.vram_ptr != nullptr) {
         page.last_used = ++tick;
@@ -335,9 +332,6 @@ int llama_weight_pager::find_page(const std::string & name) const {
 }
 
 void llama_weight_pager::page_in(llama_weight_page & page) {
-    LLAMA_LOG_INFO("page_in: loading tensor %s (file_idx=%u, offset=%zu, size=%zu)\n",
-                   page.tensor_name.c_str(), (unsigned)page.file_idx, page.file_offset, page.size);
-    // Phase 3: two-step path with async stream - NVMe → pinned staging → VRAM
     // Check if we have a valid pool and file descriptor
     if (!pool.is_valid() || pool.pinned_staging == nullptr || fds.empty() || fds[0] < 0) {
         LLAMA_LOG_WARN("page_in: no valid pool or fd (pool.valid=%s pool.pinned_staging=%p fds.empty=%s fds[0]=%d)\n",
@@ -350,10 +344,7 @@ void llama_weight_pager::page_in(llama_weight_page & page) {
 
     // Step 1: Read from NVMe into pinned host staging buffer
     int read_fd = (page.file_idx < (uint16_t)fds.size()) ? fds[page.file_idx] : (fds.empty() ? -1 : fds[0]);
-    LLAMA_LOG_INFO("page_in: pread fd=%d pinned_staging=%p size=%zu offset=%zu\n",
-                   read_fd, pool.pinned_staging, page.size, page.file_offset);
     ssize_t n = pread(read_fd, pool.pinned_staging, page.size, page.file_offset);
-    LLAMA_LOG_INFO("page_in: pread returned %zd (errno=%d)\n", n, errno);
     if (n != (ssize_t)page.size) {
         LLAMA_LOG_WARN("page_in: failed to read tensor (read %zd/%zu bytes)\n", n, page.size);
         return;
@@ -364,24 +355,21 @@ void llama_weight_pager::page_in(llama_weight_page & page) {
     pager_invalidate_slot(this, slot);
     void * dst = pool.slot_ptr(slot);
 
-    // Step 3: Copy from pinned staging to VRAM slot using hipMemcpyAsync on transfer_stream
+    // Step 3: Synchronous copy: pinned staging -> VRAM.
 #if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
-    LLAMA_LOG_INFO("page_in: hipMemcpyAsync dst=%p pinned_staging=%p size=%zu stream=%p\n",
-                   dst, pool.pinned_staging, page.size, transfer_stream);
-    hipError_t err = hipMemcpyAsync(dst, pool.pinned_staging, page.size, hipMemcpyHostToDevice, (hipStream_t)transfer_stream);
+    LLAMA_LOG_INFO("weight_pager: loading %s (%.1f MiB) -> slot %d\n",
+                   page.tensor_name.c_str(), page.size / 1048576.0f, slot);
+    hipError_t err = hipMemcpy(dst, pool.pinned_staging, page.size, hipMemcpyHostToDevice);
     if (err != hipSuccess) {
-        LLAMA_LOG_WARN("page_in: hipMemcpyAsync failed: %s\n", hipGetErrorString(err));
+        LLAMA_LOG_WARN("page_in: hipMemcpy failed: %s\n", hipGetErrorString(err));
         pool.free_slot(slot);
         return;
+    }
+    // Zero padding bytes so quantized kernel reads past tensor data are safe.
+    if (pool.slot_size > page.size) {
+        hipMemset((char*)dst + page.size, 0, pool.slot_size - page.size);
     }
 
-    // Synchronize to ensure transfer completes before returning (synchronous case)
-    err = hipStreamSynchronize((hipStream_t)transfer_stream);
-    if (err != hipSuccess) {
-        LLAMA_LOG_WARN("page_in: hipStreamSynchronize failed: %s\n", hipGetErrorString(err));
-        pool.free_slot(slot);
-        return;
-    }
 #endif
 
     // Update page state

--- a/src/llama-weight-pager.h
+++ b/src/llama-weight-pager.h
@@ -4,6 +4,9 @@
 #include <vector>
 #include <unordered_map>
 #include <stdint.h>
+#include <unistd.h>
+
+struct ggml_tensor;
 
 #ifdef LLAMA_HAVE_IO_URING
 struct io_uring;
@@ -22,24 +25,26 @@ struct prefetch_req {
 /// Represents a single weight tensor page that can be paged in/out of VRAM
 struct llama_weight_page {
     std::string  tensor_name;   // ggml tensor name (e.g. "blk.0.attn_q.weight")
+    uint16_t     file_idx;      // source file index (for split GGUFs)
     size_t       file_offset;   // byte offset in GGUF file
     size_t       size;          // tensor size in bytes
     int          slot_idx;      // VRAM slot index, -1 = not in VRAM
     uint64_t     last_used;     // monotonic counter for LRU
     void        *vram_ptr;      // pointer into slot pool, null if not loaded
 
-    llama_weight_page() : file_offset(0), size(0), slot_idx(-1), last_used(0), vram_ptr(nullptr) {}
+    llama_weight_page() : file_idx(0), file_offset(0), size(0), slot_idx(-1), last_used(0), vram_ptr(nullptr) {}
 };
 
 /// VRAM slot pool for managing contiguous weight allocations
 struct llama_vram_pool {
     void   *base;              // hipMalloc'd contiguous VRAM block
+    void   *pinned_staging;    // pinned host staging buffer
     size_t  slot_size;         // bytes per slot (= max single-layer weight size)
     int     n_slots;           // total slots = floor(pool_bytes / slot_size)
     std::vector<bool>      used;
     std::vector<uint64_t>  lru_tick; // per-slot last-used tick
 
-    llama_vram_pool() : base(nullptr), slot_size(0), n_slots(0) {}
+    llama_vram_pool() : base(nullptr), pinned_staging(nullptr), slot_size(0), n_slots(0) {}
 
     /// Allocate a slot, evicting LRU if necessary. Returns slot index.
     int alloc_slot();
@@ -57,10 +62,11 @@ struct llama_vram_pool {
 /// Weight pager: manages paging model weights between NVMe and VRAM
 struct llama_weight_pager {
     std::string              model_path;
-    int                      fd;           // open fd for io_uring reads
+    std::vector<int>         fds;          // file descriptors for each split file
     llama_vram_pool          pool;
     std::vector<llama_weight_page> pages;  // one per weight tensor
     std::unordered_map<std::string, int> name_to_page;  // tensor_name -> page index
+    std::vector<ggml_tensor*> weight_tensor_ptrs;  // actual model tensor pointers
     uint64_t                 tick = 0;
 
 #ifdef LLAMA_HAVE_IO_URING
@@ -70,7 +76,11 @@ struct llama_weight_pager {
     bool                         async_prefetch = true; // enabled by default when io_uring available
 #endif
 
-    llama_weight_pager() : fd(-1) {}
+    // Async GPU transfer stream for overlapping data transfer with compute
+    void * transfer_stream = nullptr;  // hipStream_t
+
+    llama_weight_pager() {}
+    ~llama_weight_pager();
 
     /// Ensure tensor is in VRAM. Returns VRAM pointer.
     /// If tensor already in VRAM, updates tick and returns pointer.
@@ -87,7 +97,7 @@ struct llama_weight_pager {
     void page_in(llama_weight_page & page);
 
     /// Initialize the VRAM pool with given parameters
-    void init_pool(size_t slot_size, int n_slots);
+    bool init_pool(size_t slot_size, int n_slots);
 
     /// Get the LRU slot index (for testing/debugging)
     int get_lru_slot() const;

--- a/src/llama-weight-pager.h
+++ b/src/llama-weight-pager.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <stdint.h>
+
+#ifdef LLAMA_HAVE_IO_URING
+struct io_uring;
+#endif
+
+// Forward declarations
+struct llama_vram_pool;
+
+/// Represents an in-flight async prefetch request
+struct prefetch_req {
+    int          page_idx;
+    int          slot_idx;
+    void       * dst;
+};
+
+/// Represents a single weight tensor page that can be paged in/out of VRAM
+struct llama_weight_page {
+    std::string  tensor_name;   // ggml tensor name (e.g. "blk.0.attn_q.weight")
+    size_t       file_offset;   // byte offset in GGUF file
+    size_t       size;          // tensor size in bytes
+    int          slot_idx;      // VRAM slot index, -1 = not in VRAM
+    uint64_t     last_used;     // monotonic counter for LRU
+    void        *vram_ptr;      // pointer into slot pool, null if not loaded
+
+    llama_weight_page() : file_offset(0), size(0), slot_idx(-1), last_used(0), vram_ptr(nullptr) {}
+};
+
+/// VRAM slot pool for managing contiguous weight allocations
+struct llama_vram_pool {
+    void   *base;              // hipMalloc'd contiguous VRAM block
+    size_t  slot_size;         // bytes per slot (= max single-layer weight size)
+    int     n_slots;           // total slots = floor(pool_bytes / slot_size)
+    std::vector<bool>      used;
+    std::vector<uint64_t>  lru_tick; // per-slot last-used tick
+
+    llama_vram_pool() : base(nullptr), slot_size(0), n_slots(0) {}
+
+    /// Allocate a slot, evicting LRU if necessary. Returns slot index.
+    int alloc_slot();
+
+    /// Free a slot, making it available for reuse
+    void free_slot(int idx);
+
+    /// Get pointer to slot memory
+    void* slot_ptr(int idx) { return (uint8_t*)base + (size_t)idx * slot_size; }
+
+    /// Check if pool is initialized
+    bool is_valid() const { return base != nullptr; }
+};
+
+/// Weight pager: manages paging model weights between NVMe and VRAM
+struct llama_weight_pager {
+    std::string              model_path;
+    int                      fd;           // open fd for io_uring reads
+    llama_vram_pool          pool;
+    std::vector<llama_weight_page> pages;  // one per weight tensor
+    std::unordered_map<std::string, int> name_to_page;  // tensor_name -> page index
+    uint64_t                 tick = 0;
+
+#ifdef LLAMA_HAVE_IO_URING
+    // Async io_uring reader for prefetch
+    struct llama_io_uring * io_reader = nullptr;
+    std::unordered_map<int, prefetch_req> in_flight;  // page_idx -> in-flight request
+    bool                         async_prefetch = true; // enabled by default when io_uring available
+#endif
+
+    llama_weight_pager() : fd(-1) {}
+
+    /// Ensure tensor is in VRAM. Returns VRAM pointer.
+    /// If tensor already in VRAM, updates tick and returns pointer.
+    /// If not loaded, initiates page_in (stub in Phase 1, returns nullptr).
+    void* ensure(const std::string & name);
+
+    /// Evict the least-recently-used slot
+    void evict_lru();
+
+    /// Find page index by tensor name. Returns -1 if not found.
+    int find_page(const std::string & name) const;
+
+    /// Page in a tensor from NVMe to VRAM (stub in Phase 1)
+    void page_in(llama_weight_page & page);
+
+    /// Initialize the VRAM pool with given parameters
+    void init_pool(size_t slot_size, int n_slots);
+
+    /// Get the LRU slot index (for testing/debugging)
+    int get_lru_slot() const;
+
+#ifdef LLAMA_HAVE_IO_URING
+    /// Initialize io_uring for async prefetch. Must be called after fd is set.
+    bool init_io_uring(int queue_depth = 64);
+
+    /// Submit an async prefetch for the given page index.
+    /// If the page is already in VRAM, this is a no-op.
+    void submit_prefetch(int page_idx);
+
+    /// Complete any in-flight prefetches for the given page index.
+    /// Waits for the IO if still in flight; returns true if the page is now loaded.
+    bool complete_prefetch(int page_idx);
+
+    /// Drain all in-flight prefetch requests (wait for completion).
+    void drain_prefetches();
+#endif
+};
+
+/// Eval callback for weight pager. Called before each graph node is executed.
+/// Ensures weight tensors are paged in to VRAM before use.
+/// Returns true to continue the callback, false to stop.
+bool weight_pager_eval_cb(struct ggml_tensor * t, bool ask, void * user_data);

--- a/src/llama-weight-pager.h
+++ b/src/llama-weight-pager.h
@@ -7,6 +7,8 @@
 #include <unistd.h>
 
 struct ggml_tensor;
+struct ggml_backend_buffer;
+typedef struct ggml_backend_buffer * ggml_backend_buffer_t;
 
 #ifdef LLAMA_HAVE_IO_URING
 struct io_uring;
@@ -37,14 +39,15 @@ struct llama_weight_page {
 
 /// VRAM slot pool for managing contiguous weight allocations
 struct llama_vram_pool {
-    void   *base;              // hipMalloc'd contiguous VRAM block
+    void   *base;              // device base pointer for the pool
+    ggml_backend_buffer_t ggml_buf; // ggml CUDA buffer wrapping the pool
     void   *pinned_staging;    // pinned host staging buffer
     size_t  slot_size;         // bytes per slot (= max single-layer weight size)
     int     n_slots;           // total slots = floor(pool_bytes / slot_size)
     std::vector<bool>      used;
     std::vector<uint64_t>  lru_tick; // per-slot last-used tick
 
-    llama_vram_pool() : base(nullptr), pinned_staging(nullptr), slot_size(0), n_slots(0) {}
+    llama_vram_pool() : base(nullptr), ggml_buf(nullptr), pinned_staging(nullptr), slot_size(0), n_slots(0) {}
 
     /// Allocate a slot, evicting LRU if necessary. Returns slot index.
     int alloc_slot();
@@ -73,7 +76,7 @@ struct llama_weight_pager {
     // Async io_uring reader for prefetch
     struct llama_io_uring * io_reader = nullptr;
     std::unordered_map<int, prefetch_req> in_flight;  // page_idx -> in-flight request
-    bool                         async_prefetch = true; // enabled by default when io_uring available
+    bool                         async_prefetch = false; // TODO: re-enable after fixing page-index tracking in complete_prefetch
 #endif
 
     // Async GPU transfer stream for overlapping data transfer with compute

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1,4 +1,5 @@
 #include "llama.h"
+#include <fcntl.h>
 
 #include "llama-impl.h"
 
@@ -145,24 +146,32 @@ static bool init_weight_pager(llama_model & model, llama_model_loader & ml, cons
                        __func__, model.weight_pager->weight_tensor_ptrs.size());
     }
 
+    // Always dup model file descriptors — page_in uses pread regardless of prefetch.
+    // Clear O_DIRECT on the dup'd fds: GGUF tensor offsets are not sector-aligned,
+    // so O_DIRECT would silently read from a rounded-down offset on some filesystems.
+    if (!ml.files.empty()) {
+        for (const auto & f : ml.files) {
+            int fd = dup(f->file_id());
+#ifdef O_DIRECT
+            int fl = fcntl(fd, F_GETFL);
+            if (fl != -1 && (fl & O_DIRECT)) fcntl(fd, F_SETFL, fl & ~O_DIRECT);
+#endif
+            model.weight_pager->fds.push_back(fd);
+        }
+    }
+
 #ifdef LLAMA_HAVE_IO_URING
-    // Enable async prefetch if requested and io_uring is available
+    // Enable async prefetch via io_uring only when explicitly requested.
     model.weight_pager->async_prefetch = params.weight_paging_prefetch;
 
-    if (params.weight_paging_prefetch) {
-        // Open the model file for io_uring reads
-        if (!ml.files.empty()) {
-            for (const auto & f : ml.files) {
-                model.weight_pager->fds.push_back(dup(f->file_id()));
-            }
-            int fd = model.weight_pager->fds.empty() ? -1 : model.weight_pager->fds[0];
-            if (fd >= 0) {
-                if (model.weight_pager->init_io_uring(64)) {
-                    LLAMA_LOG_INFO("%s: io_uring initialized for async prefetch\n", __func__);
-                } else {
-                    LLAMA_LOG_WARN("%s: failed to initialize io_uring, disabling async prefetch\n", __func__);
-                    model.weight_pager->async_prefetch = false;
-                }
+    if (params.weight_paging_prefetch && !model.weight_pager->fds.empty()) {
+        int fd = model.weight_pager->fds[0];
+        if (fd >= 0) {
+            if (model.weight_pager->init_io_uring(64)) {
+                LLAMA_LOG_INFO("%s: io_uring initialized for async prefetch\n", __func__);
+            } else {
+                LLAMA_LOG_WARN("%s: failed to initialize io_uring, disabling async prefetch\n", __func__);
+                model.weight_pager->async_prefetch = false;
             }
         }
     }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -9,6 +9,11 @@
 #include "llama-model-loader.h"
 #include "llama-model-saver.h"
 #include "llama-model.h"
+#include "llama-weight-pager.h"
+
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+#include <hip/hip_runtime.h>
+#endif
 
 #include "ggml.h"
 #include "ggml-cpp.h"
@@ -33,6 +38,140 @@
 //
 // interface implementation
 //
+
+//
+// Weight pager initialization helper
+//
+
+static bool init_weight_pager(llama_model & model, llama_model_loader & ml, const llama_model_params & params) {
+    if (!params.weight_paging_enabled) {
+        return true;
+    }
+
+    if (ml.weight_page_infos.empty()) {
+        LLAMA_LOG_WARN("%s: weight paging enabled but no weight page info available\n", __func__);
+        return true;
+    }
+
+    LLAMA_LOG_INFO("%s: initializing weight pager with %zu pages\n", __func__, ml.weight_page_infos.size());
+
+    // Create the weight pager if not already created (it may have been created early to allow
+    // load_tensors to collect tensor pointers into it before pool init)
+    if (!model.weight_pager) {
+        model.weight_pager = std::make_unique<llama_weight_pager>();
+    }
+
+    // Initialize the page table with weight tensor info
+    size_t max_weight_size = 0;
+    for (const auto & info : ml.weight_page_infos) {
+        llama_weight_page page;
+        page.tensor_name = info.name;
+        page.file_idx    = info.file_idx;
+        page.file_offset = info.offset;
+        page.size = info.size;
+        model.weight_pager->pages.push_back(page);
+        model.weight_pager->name_to_page[info.name] = (int(model.weight_pager->pages.size()) - 1);
+        if (info.size > max_weight_size) {
+            max_weight_size = info.size;
+        }
+    }
+
+    // Determine number of slots
+    int n_slots = params.weight_paging_slots;
+    if (n_slots <= 0) {
+        // Auto: use the number of layers as default
+        n_slots = (int)model.hparams.n_layer;
+        if (n_slots <= 0) {
+            n_slots = 32; // fallback
+        }
+    }
+
+    // Query free VRAM before allocating the pool
+#if defined(GGML_USE_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    {
+        size_t free_vram = 0, total_vram = 0;
+        hipMemGetInfo(&free_vram, &total_vram);
+        LLAMA_LOG_INFO("%s: VRAM: %zu MiB free / %zu MiB total\n",
+                       __func__, free_vram / (1024*1024), total_vram / (1024*1024));
+        // Leave headroom for KV cache, compute buffers
+        const size_t vram_reserve = 3ULL * 1024 * 1024 * 1024;
+        const size_t usable = (free_vram > vram_reserve) ? (free_vram - vram_reserve) : 0;
+        int n_slots_fit = (max_weight_size > 0) ? (int)(usable / max_weight_size) : 0;
+        if (n_slots_fit < 1) {
+            n_slots_fit = 1; // always try at least 1
+        }
+        if (n_slots > n_slots_fit) {
+            LLAMA_LOG_WARN("%s: capping slots %d → %d to fit in available VRAM (%zu MiB free, %zu MiB/slot)\n",
+                           __func__, n_slots, n_slots_fit,
+                           free_vram / (1024*1024), max_weight_size / (1024*1024));
+            n_slots = n_slots_fit;
+        }
+    }
+#endif
+
+    LLAMA_LOG_INFO("%s: initializing VRAM pool with %d slots (%zu MiB each = %zu MiB total)\n",
+                   __func__, n_slots, max_weight_size / (1024*1024),
+                   (size_t)n_slots * max_weight_size / (1024*1024));
+
+    // Initialize the VRAM pool
+    LLAMA_LOG_INFO("%s: calling init_pool with slot_size=%zu n_slots=%d\n",
+                   __func__, max_weight_size, n_slots);
+    if (!model.weight_pager->init_pool(max_weight_size, n_slots)) {
+        LLAMA_LOG_ERROR("%s: init_pool returned false\n", __func__);
+        throw std::runtime_error(format(
+            "weight pager: VRAM pool allocation failed "
+            "(%d slots x %zu MiB = %zu MiB required). "
+            "Try reducing --weight-paging-slots.",
+            n_slots,
+            max_weight_size / (1024*1024),
+            (size_t)n_slots * max_weight_size / (1024*1024)));
+    }
+    LLAMA_LOG_INFO("%s: init_pool succeeded\n", __func__);
+
+    // Set a placeholder data pointer on all weight tensors so the graph allocator
+    // skips them (it checks tensor->data != NULL to determine if allocation is needed).
+    // The eval callback will overwrite tensor->data with the correct VRAM slot before each kernel.
+    // Use the actual model tensor pointers collected during load_tensors, not the GGUF metadata tensors.
+    {
+        void * placeholder = model.weight_pager->pool.base;
+        for (ggml_tensor * t : model.weight_pager->weight_tensor_ptrs) {
+            if (t && t->data == nullptr) {
+                t->data = placeholder;
+                // Also clear the buffer so the allocator skips this tensor
+                t->buffer = nullptr;
+            }
+        }
+        LLAMA_LOG_INFO("%s: set placeholder data pointers on %zu weight tensors\n",
+                       __func__, model.weight_pager->weight_tensor_ptrs.size());
+    }
+
+#ifdef LLAMA_HAVE_IO_URING
+    // Enable async prefetch if requested and io_uring is available
+    model.weight_pager->async_prefetch = params.weight_paging_prefetch;
+
+    if (params.weight_paging_prefetch) {
+        // Open the model file for io_uring reads
+        if (!ml.files.empty()) {
+            for (const auto & f : ml.files) {
+                model.weight_pager->fds.push_back(dup(f->file_id()));
+            }
+            int fd = model.weight_pager->fds.empty() ? -1 : model.weight_pager->fds[0];
+            if (fd >= 0) {
+                if (model.weight_pager->init_io_uring(64)) {
+                    LLAMA_LOG_INFO("%s: io_uring initialized for async prefetch\n", __func__);
+                } else {
+                    LLAMA_LOG_WARN("%s: failed to initialize io_uring, disabling async prefetch\n", __func__);
+                    model.weight_pager->async_prefetch = false;
+                }
+            }
+        }
+    }
+#endif
+
+    LLAMA_LOG_INFO("%s: weight pager initialized\n", __func__);
+
+    return true;
+}
 
 const char * llama_flash_attn_type_name(enum llama_flash_attn_type flash_attn_type) {
     switch (flash_attn_type) {
@@ -157,9 +296,17 @@ static int llama_model_load(struct gguf_context * metadata, llama_model_set_tens
             return 0;
         }
 
+        // Create the weight pager object early so load_tensors can collect tensor ptrs into it
+        if (params.weight_paging_enabled) {
+            model.weight_pager = std::make_unique<llama_weight_pager>();
+        }
+
         if (!model.load_tensors(ml)) {
             return -2;
         }
+
+        // Initialize weight pager if enabled (pool alloc, page table, fds)
+        init_weight_pager(model, ml, params);
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: error loading model: %s\n", __func__, err.what());
         return -1;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -5,3 +5,7 @@
 ggml-common.h
 **/*.swp
 !peg-parser
+
+cmake_install.cmake
+CTestTestfile.cmake
+*.a

--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(${TARGET} STATIC
     server-common.h
     server-context.cpp
     server-context.h
+    server-tiered-cache.cpp
+    server-tiered-cache.h
     server-tools.cpp
     server-tools.h
 )

--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -27,6 +27,11 @@ endif()
 
 target_include_directories(${TARGET} PRIVATE ../mtmd)
 target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/src)
+if(GGML_HIP)
+    target_include_directories(${TARGET} PRIVATE /opt/rocm/include)
+    target_compile_definitions(${TARGET} PRIVATE __HIP_PLATFORM_AMD__)
+endif()
 target_link_libraries(${TARGET} PUBLIC llama-common mtmd ${CMAKE_THREAD_LIBS_INIT})
 
 
@@ -72,6 +77,11 @@ install(TARGETS ${TARGET} RUNTIME)
 
 target_include_directories(${TARGET} PRIVATE ../mtmd)
 target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/src)
+if(GGML_HIP)
+    target_include_directories(${TARGET} PRIVATE /opt/rocm/include)
+endif()
+    target_compile_definitions(${TARGET} PRIVATE __HIP_PLATFORM_AMD__)
 target_link_libraries(${TARGET} PRIVATE server-context PUBLIC llama-common cpp-httplib ${CMAKE_THREAD_LIBS_INIT})
 
 target_compile_features(${TARGET} PRIVATE cxx_std_17)

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -922,7 +922,7 @@ private:
 
             // initialize tier manager for slot if enabled
             if (params_base.kv_tiered_enabled) {
-                if (!tiered_cache->init_slot(i, *model)) {
+                if (!tiered_cache->init_slot(i, *model, ctx)) {
                     SRV_WRN("failed to initialize tier manager for slot %d\n", i);
                 } else {
                     SLT_INF(slot, "tier manager initialized for slot %s\n", "");
@@ -1408,6 +1408,24 @@ private:
 
         if (incomplete) {
             slot.has_next_token = true;
+        }
+
+        // Proactive tiered cache eviction: when hot tier reaches 80% capacity,
+        // evict oldest tokens to warm/cold to make room. Works for all architectures
+        // including hybrids that don't support ctx_shift.
+        if (params_base.kv_tiered_enabled && tiered_cache) {
+            const int n_tokens = slot.prompt.n_tokens();
+            const int evict_threshold = (int)(slot.n_ctx * 0.80f);
+            if (n_tokens >= evict_threshold) {
+                auto* slot_tier = tiered_cache->get_slot_manager(slot.id);
+                if (slot_tier && slot_tier->initialized) {
+                    const int n_evict = std::max(1, (int)(slot.n_ctx * 0.20f));
+                    if (tiered_cache->evict_from_slot(slot.id, n_evict, (uint32_t)n_tokens)) {
+                        SLT_INF(slot, "proactive tiered eviction: %d tokens at %d/%d hot capacity\\n",
+                                n_evict, n_tokens, slot.n_ctx);
+                    }
+                }
+            }
         }
 
         // if context shifting is disabled, make sure that we don't run out of context
@@ -2209,7 +2227,7 @@ private:
                         // Evict tokens to tiered cache before context shift
                         int n_evict = std::min(n_discard, int(slot_tier->tiered_cache->get_config().cold_capacity()));
                         if (n_evict > 0) {
-                            if (tiered_cache->evict_from_slot(slot.id, n_evict)) {
+                            if (tiered_cache->evict_from_slot(slot.id, n_evict, (uint32_t)slot.prompt.n_tokens())) {
                                 SLT_INF(slot, "tiered cache eviction: %d tokens\n", n_evict);
                             }
                         }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -634,6 +634,7 @@ struct server_metrics {
 
 struct server_context_impl {
     friend struct server_context;
+    friend struct server_routes;
 
 public:
     // only use these pointers outside of this class:
@@ -683,7 +684,7 @@ private:
     int n_empty_consecutive = 0;
 
     std::unique_ptr<server_prompt_cache> prompt_cache;
-    server_tiered_cache tiered_cache;
+    std::unique_ptr<server_tiered_cache> tiered_cache;
 
     server_metrics metrics;
 
@@ -858,7 +859,7 @@ private:
 
         // Initialize tiered cache if enabled
         if (params_base.kv_tiered_enabled) {
-            tiered_cache = server_tiered_cache(params_base);
+            tiered_cache = std::make_unique<server_tiered_cache>(params_base);
             SRV_INF("tiered cache initialized, hot=%f%%, warm=%f%%, cold=%f%%\n",
                     params_base.kv_tier_hot_pct, params_base.kv_tier_warm_pct, params_base.kv_tier_cold_pct);
         }
@@ -916,10 +917,10 @@ private:
 
             // initialize tier manager for slot if enabled
             if (params_base.kv_tiered_enabled) {
-                if (!tiered_cache.init_slot(i, *model)) {
+                if (!tiered_cache->init_slot(i, *model)) {
                     SRV_WRN("failed to initialize tier manager for slot %d\n", i);
                 } else {
-                    SLT_INF(slot, "tier manager initialized for slot\n");
+                    SLT_INF(slot, "tier manager initialized for slot %s\n", "");
                 }
             }
 
@@ -2184,20 +2185,6 @@ private:
                     continue;
                 }
 
-                // Try tiered cache eviction before context shift
-                if (params_base.kv_tiered_enabled) {
-                    auto* slot_tier = tiered_cache.get_slot_manager(slot.id);
-                    if (slot_tier && slot_tier->initialized) {
-                        // Evict tokens to tiered cache before context shift
-                        int n_evict = std::min(n_discard, int(slot_tier->tiered_cache->get_config().cold_capacity()));
-                        if (n_evict > 0) {
-                            if (tiered_cache.evict_from_slot(slot.id, n_evict)) {
-                                SLT_INF(slot, "tiered cache eviction: %d tokens\n", n_evict);
-                            }
-                        }
-                    }
-                }
-
                 // Shift context
                 int n_keep = slot.task->params.n_keep < 0 ? slot.task->n_tokens() : slot.task->params.n_keep;
 
@@ -2209,6 +2196,20 @@ private:
 
                 const int n_left    = slot.prompt.n_tokens() - n_keep;
                 const int n_discard = slot.task->params.n_discard ? slot.task->params.n_discard : (n_left / 2);
+
+                // Try tiered cache eviction before context shift
+                if (params_base.kv_tiered_enabled) {
+                    auto* slot_tier = tiered_cache->get_slot_manager(slot.id);
+                    if (slot_tier && slot_tier->initialized) {
+                        // Evict tokens to tiered cache before context shift
+                        int n_evict = std::min(n_discard, int(slot_tier->tiered_cache->get_config().cold_capacity()));
+                        if (n_evict > 0) {
+                            if (tiered_cache->evict_from_slot(slot.id, n_evict)) {
+                                SLT_INF(slot, "tiered cache eviction: %d tokens\n", n_evict);
+                            }
+                        }
+                    }
+                }
 
                 SLT_WRN(slot, "slot context shift, n_keep = %d, n_left = %d, n_discard = %d\n", n_keep, n_left, n_discard);
 
@@ -3532,33 +3533,13 @@ void server_routes::init_routes() {
         };
 
         // Add tiered cache metrics if enabled
-        if (params.kv_tiered_enabled) {
-            auto global_stats = tiered_cache.get_global_stats();
-            all_metrics_def["counter"].push({
-                {"name",  "tier_evictions_total"},
-                {"help",  "Total number of tier evictions"},
-                {"value", global_stats.total_evictions}
-            });
-            all_metrics_def["counter"].push({
-                {"name",  "tier_migrations_total"},
-                {"help",  "Total number of tier migrations"},
-                {"value", global_stats.total_migrations}
-            });
-            all_metrics_def["counter"].push({
-                {"name",  "tier_cache_hits_total"},
-                {"help",  "Total cache hits"},
-                {"value", global_stats.total_cache_hits}
-            });
-            all_metrics_def["counter"].push({
-                {"name",  "tier_cache_misses_total"},
-                {"help",  "Total cache misses"},
-                {"value", global_stats.total_cache_misses}
-            });
-            all_metrics_def["gauge"].push({
-                {"name",  "tier_migration_latency_seconds"},
-                {"help",  "Total migration latency in seconds"},
-                {"value", global_stats.total_migration_latency_us / 1e6}
-            });
+        if (params.kv_tiered_enabled && ctx_server.tiered_cache) {
+            auto global_stats = ctx_server.tiered_cache->get_global_stats();
+            { json m; m["name"] = "tier_evictions_total"; m["help"] = "Total number of tier evictions"; m["value"] = global_stats.total_evictions; all_metrics_def["counter"].push_back(m); }
+            { json m; m["name"] = "tier_migrations_total"; m["help"] = "Total number of tier migrations"; m["value"] = global_stats.total_migrations; all_metrics_def["counter"].push_back(m); }
+            { json m; m["name"] = "tier_cache_hits_total"; m["help"] = "Total cache hits"; m["value"] = global_stats.total_cache_hits; all_metrics_def["counter"].push_back(m); }
+            { json m; m["name"] = "tier_cache_misses_total"; m["help"] = "Total cache misses"; m["value"] = global_stats.total_cache_misses; all_metrics_def["counter"].push_back(m); }
+            { json m; m["name"] = "tier_migration_latency_seconds"; m["help"] = "Total migration latency in seconds"; m["value"] = global_stats.total_migration_latency_us / 1e6; all_metrics_def["gauge"].push_back(m); }
         }
 
         std::stringstream prometheus;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -750,6 +750,11 @@ private:
         SRV_INF("loading model '%s'\n", params.model.path.c_str());
 
         params_base = params;
+        if (params_base.kv_tiered_enabled && params_base.kv_tier_hot_pct > 0.0f && params_base.kv_tier_hot_pct < 100.0f) {
+            params_base.kv_tier_total_ctx = params_base.n_ctx;
+            params_base.n_ctx = std::max(512, (int)(params_base.n_ctx * params_base.kv_tier_hot_pct / 100.0f));
+            SRV_INF("tiered KV: total ctx=%d, hot ctx=%d (%.0f%%)\n", params_base.kv_tier_total_ctx, params_base.n_ctx, params_base.kv_tier_hot_pct);
+        }
 
         llama_init = common_init_from_params(params_base);
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -877,7 +877,9 @@ private:
 
         const int n_ctx_train = llama_model_n_ctx_train(model);
 
-        int n_ctx_slot = llama_n_ctx_seq(ctx);
+        int n_ctx_slot = (params_base.kv_tiered_enabled && params_base.kv_tier_total_ctx > 0)
+                         ? params_base.kv_tier_total_ctx
+                         : llama_n_ctx_seq(ctx);
         if (n_ctx_slot > n_ctx_train) {
             SRV_WRN("the slot context (%d) exceeds the training context of the model (%d) - using rope scaling to extend\n", n_ctx_slot, n_ctx_train);
             // Do not cap: caller has configured rope scaling (--rope-scale / --rope-scaling yarn) to handle extended context.

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -6,6 +6,7 @@
 #include "server-task.h"
 #include "server-queue.h"
 #include "server-tiered-cache.h"
+#include "../src/llama-model.h"
 
 #include "build-info.h"
 #include "common.h"
@@ -3628,14 +3629,18 @@ void server_routes::init_routes() {
             }}}
         };
 
-        // Add tiered cache metrics if enabled
-        if (params.kv_tiered_enabled && ctx_server.tiered_cache) {
-            auto global_stats = ctx_server.tiered_cache->get_global_stats();
-            { json m; m["name"] = "tier_evictions_total"; m["help"] = "Total number of tier evictions"; m["value"] = global_stats.total_evictions; all_metrics_def["counter"].push_back(m); }
-            { json m; m["name"] = "tier_migrations_total"; m["help"] = "Total number of tier migrations"; m["value"] = global_stats.total_migrations; all_metrics_def["counter"].push_back(m); }
-            { json m; m["name"] = "tier_cache_hits_total"; m["help"] = "Total cache hits"; m["value"] = global_stats.total_cache_hits; all_metrics_def["counter"].push_back(m); }
-            { json m; m["name"] = "tier_cache_misses_total"; m["help"] = "Total cache misses"; m["value"] = global_stats.total_cache_misses; all_metrics_def["counter"].push_back(m); }
-            { json m; m["name"] = "tier_migration_latency_seconds"; m["help"] = "Total migration latency in seconds"; m["value"] = global_stats.total_migration_latency_us / 1e6; all_metrics_def["gauge"].push_back(m); }
+        // Add weight pager metrics if enabled
+        if (ctx_server.model && ctx_server.model->weight_pager) {
+            auto * pager = ctx_server.model->weight_pager.get();
+            { json m; m["name"] = "llama_weight_pager_pages_total"; m["help"] = "Total number of weight pages tracked"; m["value"] = (double)pager->pages.size(); all_metrics_def["gauge"].push_back(m); }
+            { json m; m["name"] = "llama_weight_pager_loaded_pages"; m["help"] = "Number of pages currently loaded in VRAM";
+              size_t loaded = 0;
+              for (const auto & page : pager->pages) { if (page.slot_idx >= 0) loaded++; }
+              m["value"] = (double)loaded; all_metrics_def["gauge"].push_back(m); }
+#ifdef LLAMA_HAVE_IO_URING
+            { json m; m["name"] = "llama_weight_pager_in_flight_prefetches"; m["help"] = "Number of in-flight prefetch requests"; m["value"] = (double)pager->in_flight.size(); all_metrics_def["gauge"].push_back(m); }
+            { json m; m["name"] = "llama_weight_pager_async_prefetch_enabled"; m["help"] = "Async prefetch enabled (1=true, 0=false)"; m["value"] = pager->async_prefetch ? 1.0 : 0.0; all_metrics_def["gauge"].push_back(m); }
+#endif
         }
 
         std::stringstream prometheus;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -5,6 +5,7 @@
 #include "server-http.h"
 #include "server-task.h"
 #include "server-queue.h"
+#include "server-tiered-cache.h"
 
 #include "build-info.h"
 #include "common.h"
@@ -682,6 +683,7 @@ private:
     int n_empty_consecutive = 0;
 
     std::unique_ptr<server_prompt_cache> prompt_cache;
+    server_tiered_cache tiered_cache;
 
     server_metrics metrics;
 
@@ -854,6 +856,13 @@ private:
             }
         }
 
+        // Initialize tiered cache if enabled
+        if (params_base.kv_tiered_enabled) {
+            tiered_cache = server_tiered_cache(params_base);
+            SRV_INF("tiered cache initialized, hot=%f%%, warm=%f%%, cold=%f%%\n",
+                    params_base.kv_tier_hot_pct, params_base.kv_tier_warm_pct, params_base.kv_tier_cold_pct);
+        }
+
         // Necessary similarity of prompt for slot selection
         slot_prompt_similarity = params_base.slot_prompt_similarity;
 
@@ -902,6 +911,15 @@ private:
 
                 if (slot.spec) {
                     SLT_INF(slot, "%s", "speculative decoding context initialized\n");
+                }
+            }
+
+            // initialize tier manager for slot if enabled
+            if (params_base.kv_tiered_enabled) {
+                if (!tiered_cache.init_slot(i, *model)) {
+                    SRV_WRN("failed to initialize tier manager for slot %d\n", i);
+                } else {
+                    SLT_INF(slot, "tier manager initialized for slot\n");
                 }
             }
 
@@ -2164,6 +2182,20 @@ private:
                     send_error(slot, "context shift cannot be used for shared prompt", ERROR_TYPE_SERVER);
                     slot.release();
                     continue;
+                }
+
+                // Try tiered cache eviction before context shift
+                if (params_base.kv_tiered_enabled) {
+                    auto* slot_tier = tiered_cache.get_slot_manager(slot.id);
+                    if (slot_tier && slot_tier->initialized) {
+                        // Evict tokens to tiered cache before context shift
+                        int n_evict = std::min(n_discard, int(slot_tier->tiered_cache->get_config().cold_capacity()));
+                        if (n_evict > 0) {
+                            if (tiered_cache.evict_from_slot(slot.id, n_evict)) {
+                                SLT_INF(slot, "tiered cache eviction: %d tokens\n", n_evict);
+                            }
+                        }
+                    }
                 }
 
                 // Shift context
@@ -3498,6 +3530,36 @@ void server_routes::init_routes() {
                     {"value",  (uint64_t) res_task->n_tasks_deferred}
             }}}
         };
+
+        // Add tiered cache metrics if enabled
+        if (params.kv_tiered_enabled) {
+            auto global_stats = tiered_cache.get_global_stats();
+            all_metrics_def["counter"].push({
+                {"name",  "tier_evictions_total"},
+                {"help",  "Total number of tier evictions"},
+                {"value", global_stats.total_evictions}
+            });
+            all_metrics_def["counter"].push({
+                {"name",  "tier_migrations_total"},
+                {"help",  "Total number of tier migrations"},
+                {"value", global_stats.total_migrations}
+            });
+            all_metrics_def["counter"].push({
+                {"name",  "tier_cache_hits_total"},
+                {"help",  "Total cache hits"},
+                {"value", global_stats.total_cache_hits}
+            });
+            all_metrics_def["counter"].push({
+                {"name",  "tier_cache_misses_total"},
+                {"help",  "Total cache misses"},
+                {"value", global_stats.total_cache_misses}
+            });
+            all_metrics_def["gauge"].push({
+                {"name",  "tier_migration_latency_seconds"},
+                {"help",  "Total migration latency in seconds"},
+                {"value", global_stats.total_migration_latency_us / 1e6}
+            });
+        }
 
         std::stringstream prometheus;
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2740,6 +2740,76 @@ private:
 
                         slot.init_sampler();
                         SLT_INF(slot, "prompt processing done, n_tokens = %d, batch.n_tokens = %d\n", slot.prompt.n_tokens(), batch.n_tokens);
+                        
+                        // Get and log prefetch hints if semantic index is enabled
+                        if (params_base.kv_tiered_enabled && tiered_cache->sem_enabled()) {
+                            auto* slot_tier = tiered_cache->get_slot_manager(slot.id);
+                            if (slot_tier && slot_tier->initialized) {
+                                // Get the input text from the prompt tokens
+                                std::string input_text;
+                                const auto & input_tokens = slot.task->tokens;
+                                for (size_t i = 0; i < input_tokens.size(); ++i) {
+                                    auto piece = common_token_to_piece(ctx, input_tokens[i]);
+                                    input_text += piece;
+                                }
+                                
+                                // Get prefetch hints
+                                auto hints = tiered_cache->get_prefetch_hints(slot.id, input_text, tiered_cache->semantic_top_k);
+                                
+                                // Log the hints
+                                for (const auto& hint : hints) {
+                                    std::string positions_str;
+                                    if (!hint.positions.empty()) {
+                                        std::ostringstream oss;
+                                        oss << hint.positions.front() << ".." << hint.positions.back();
+                                        positions_str = oss.str();
+                                    } else {
+                                        positions_str = "empty";
+                                    }
+                                    const char* tier_name = hint.current_tier == TIER_WARM ? "warm" :
+                                                            hint.current_tier == TIER_COLD ? "cold" : "hot";
+                                    SLT_INF(slot, "semantic prefetch: score=%.2f positions=[%s] tier=%s\n",
+                                            hint.score, positions_str.c_str(), tier_name);
+                                }
+                                
+                                // Apply prefetch migration for WARM tier hints
+                                for (const auto& hint : hints) {
+                                    if (hint.current_tier == TIER_WARM) {
+                                        // Migrate WARM tokens to HOT tier
+                                        if (tiered_cache->migrate_in_slot(slot.id, hint.positions, TIER_WARM, TIER_HOT)) {
+                                            SLT_INF(slot, "semantic prefetch: migrated %zu warm tokens to hot\n", hint.positions.size());
+                                            auto* slot_mgr = tiered_cache->get_slot_manager(slot.id);
+                                            if (slot_mgr) {
+                                                slot_mgr->stats.semantic_prefetch_hits += (uint32_t)hint.positions.size();
+                                            }
+                                        } else {
+                                            SLT_WRN(slot, "semantic prefetch: failed to migrate %zu warm tokens\n", hint.positions.size());
+                                        }
+                                    } else if (hint.current_tier == TIER_COLD) {
+                                        // Stage cold→warm→hot: first bring cold to warm, then warm to hot
+                                        if (tiered_cache->migrate_in_slot(slot.id, hint.positions, TIER_COLD, TIER_WARM)) {
+                                            if (tiered_cache->migrate_in_slot(slot.id, hint.positions, TIER_WARM, TIER_HOT)) {
+                                                SLT_INF(slot, "semantic prefetch: staged %zu cold tokens to hot\n", hint.positions.size());
+                                                auto* slot_mgr = tiered_cache->get_slot_manager(slot.id);
+                                                if (slot_mgr) {
+                                                    slot_mgr->stats.semantic_prefetch_hits += (uint32_t)hint.positions.size();
+                                                }
+                                            } else {
+                                                SLT_WRN(slot, "semantic prefetch: cold->warm ok but warm->hot failed for %zu tokens\n", hint.positions.size());
+                                            }
+                                        } else {
+                                            SLT_WRN(slot, "semantic prefetch: failed to stage %zu cold tokens\n", hint.positions.size());
+                                        }
+                                    }
+                                }
+                                
+                                // Set the current query embedding for semantic eviction weighting
+                                auto embedding = tiered_cache->embed(input_text);
+                                if (!embedding.empty()) {
+                                    slot_tier->tiered_cache->set_current_query_embedding(embedding);
+                                }
+                            }
+                        }
                     } else {
                         if (slot.task->n_tokens() < slot.prompt.n_tokens() + n_ubatch) {
                             // near the end of the prompt

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1421,7 +1421,7 @@ private:
                 if (slot_tier && slot_tier->initialized) {
                     const int n_evict = std::max(1, (int)(slot.n_ctx * 0.20f));
                     if (tiered_cache->evict_from_slot(slot.id, n_evict, (uint32_t)n_tokens)) {
-                        SLT_INF(slot, "proactive tiered eviction: %d tokens at %d/%d hot capacity\\n",
+                        SLT_DBG(slot, "proactive tiered eviction: %d tokens at %d/%d hot capacity\\n",
                                 n_evict, n_tokens, slot.n_ctx);
                     }
                 }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2257,6 +2257,7 @@ private:
                     slot.prompt.tokens.insert(new_tokens);
                 }
 
+                slot.prompt.checkpoints.clear();
                 slot.truncated = true;
             }
         }

--- a/tools/server/server-tiered-cache.cpp
+++ b/tools/server/server-tiered-cache.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 
 server_tiered_cache::server_tiered_cache(const common_params& params)
     : params(params) {
@@ -28,7 +29,40 @@ server_tiered_cache::server_tiered_cache(const common_params& params)
         // Extract attention threshold
         attention_threshold = params.kv_tier_attention_threshold;
 
+        // Extract semantic threshold and top_k
+        semantic_threshold = params.kv_semantic_threshold;
+        semantic_top_k = params.kv_semantic_top_k;
+
         stats_.reset();
+    }
+
+    // Load semantic embedding model if specified
+    if (!params.kv_semantic_index.empty()) {
+        auto sem_params = llama_model_default_params();
+        sem_params.n_gpu_layers = 0; // CPU only
+        sem_params.progress_callback = NULL;
+
+        sem_model = llama_model_load_from_file(params.kv_semantic_index.c_str(), sem_params);
+        if (!sem_model) {
+            SRV_ERR("failed to load semantic index model: %s\n", params.kv_semantic_index.c_str());
+            return;
+        }
+
+        auto ctx_params = llama_context_default_params();
+        ctx_params.n_ctx = 512;
+        ctx_params.embeddings = true;
+        ctx_params.n_batch = 512;
+        ctx_params.n_ubatch = 512;
+
+        sem_ctx = llama_init_from_model(sem_model, ctx_params);
+        if (!sem_ctx) {
+            LOG_ERR("failed to create context for semantic index model\n");
+            llama_model_free(sem_model);
+            sem_model = nullptr;
+            return;
+        }
+
+        SRV_INF("semantic KV index loaded: %s (CPU)\n", params.kv_semantic_index.c_str());
     }
 }
 
@@ -36,6 +70,77 @@ server_tiered_cache::~server_tiered_cache() {
     // Cleanup all slot managers
     std::lock_guard<std::mutex> lock(mutex);
     slot_managers.clear();
+
+    // Cleanup semantic embedding model
+    if (sem_ctx) {
+        llama_free(sem_ctx);
+        sem_ctx = nullptr;
+    }
+    if (sem_model) {
+        llama_model_free(sem_model);
+        sem_model = nullptr;
+    }
+}
+
+std::vector<float> server_tiered_cache::embed(const std::string & text) {
+    if (!sem_ctx || !sem_model) {
+        return {};
+    }
+
+    // Tokenize the input text
+    auto * vocab = llama_model_get_vocab(sem_model);
+    std::vector<llama_token> tokens(256);
+    int32_t n_tokens = llama_tokenize(vocab, text.c_str(), (int32_t)text.size(),
+                                      tokens.data(), (int32_t)tokens.capacity(),
+                                      true, true);
+    if (n_tokens < 0) {
+        // Tokenization failed, try without add_special
+        n_tokens = llama_tokenize(vocab, text.c_str(), (int32_t)text.size(),
+                                  tokens.data(), (int32_t)tokens.capacity(),
+                                  false, false);
+        if (n_tokens < 0) {
+            return {};
+        }
+    }
+    tokens.resize(n_tokens);
+
+    if (tokens.empty()) {
+        return {};
+    }
+
+    // Create a batch and decode to get embeddings
+    auto batch = llama_batch_get_one(tokens.data(), n_tokens);
+    int32_t result = llama_decode(sem_ctx, batch);
+    if (result != 0) {
+        SRV_WRN("embed: llama_decode failed with code %d\n", result);
+        llama_batch_free(batch);
+        return {};
+    }
+    llama_batch_free(batch);
+
+    // Extract embeddings for sequence 0
+    float * embd_ptr = llama_get_embeddings_seq(sem_ctx, 0);
+    if (!embd_ptr) {
+        return {};
+    }
+
+    // Get embedding dimension
+    int32_t n_embd = llama_model_n_embd(sem_model);
+    std::vector<float> embedding(embd_ptr, embd_ptr + n_embd);
+
+    // L2-normalize the embedding vector
+    float norm = 0.0f;
+    for (int32_t i = 0; i < n_embd; ++i) {
+        norm += embedding[i] * embedding[i];
+    }
+    norm = std::sqrt(norm);
+    if (norm > 1e-9f) {
+        for (int32_t i = 0; i < n_embd; ++i) {
+            embedding[i] /= norm;
+        }
+    }
+
+    return embedding;
 }
 
 bool server_tiered_cache::init_slot(int slot_id, const llama_model& model, struct llama_context * lctx) {
@@ -51,6 +156,9 @@ bool server_tiered_cache::init_slot(int slot_id, const llama_model& model, struc
         // Already initialized
         return true;
     }
+
+    // Store model pointer for detokenization
+    detokenize_model = &model;
 
     // Create new slot manager
     slot_tier_manager manager;
@@ -129,6 +237,38 @@ bool server_tiered_cache::evict_from_slot(int slot_id, uint32_t n_tokens, uint32
         // Update global stats
         std::lock_guard<std::mutex> lock(mutex);
         stats_.total_evictions += n_tokens;
+        
+        // If semantic index is enabled, compute fingerprint for evicted tokens
+        if (sem_enabled() && detokenize_model && n_tokens > 0) {
+            // Create positions vector for the evicted tokens
+            std::vector<llama_pos> positions(n_tokens);
+            for (uint32_t i = 0; i < n_tokens; i++) {
+                positions[i] = i;  // Simplified - should track actual positions from tiered cache
+            }
+            
+            // Detokenize to get text for embedding
+            std::string text;
+            auto * vocab = llama_model_get_vocab(detokenize_model);
+            for (auto pos : positions) {
+                std::vector<char> buf(64);
+                int len = llama_token_to_piece(vocab, pos, buf.data(), buf.size(), 0, false);
+                if (len > 0) {
+                    text.append(buf.data(), len);
+                }
+            }
+            
+            // Compute embedding
+            auto embedding = embed(text);
+            if (!embedding.empty()) {
+                // Add fingerprint to tiered cache
+                manager->tiered_cache->add_fingerprint(positions, embedding, TIER_WARM);
+                
+                // Save fingerprints to disk
+                if (!fingerprints_path.empty()) {
+                    manager->tiered_cache->save_fingerprints_to_disk(fingerprints_path + "/fingerprints.bin");
+                }
+            }
+        }
     }
 
     return result;
@@ -180,4 +320,26 @@ server_tiered_cache::global_stats server_tiered_cache::get_global_stats() {
 void server_tiered_cache::reset_stats() {
     std::lock_guard<std::mutex> lock(mutex);
     stats_.reset();
+}
+
+std::vector<llama_kv_cache_tiered::PrefetchHint>
+server_tiered_cache::get_prefetch_hints(int slot_id, const std::string& input_text, int top_k) {
+    if (!sem_enabled()) {
+        return {};
+    }
+    
+    // Embed the input text
+    auto embedding = embed(input_text);
+    if (embedding.empty()) {
+        return {};
+    }
+    
+    // Get the slot manager
+    auto* manager = get_slot_manager(slot_id);
+    if (!manager || !manager->initialized) {
+        return {};
+    }
+    
+    // Score fingerprints and return hints
+    return manager->tiered_cache->score_fingerprints(embedding, top_k, semantic_threshold);
 }

--- a/tools/server/server-tiered-cache.cpp
+++ b/tools/server/server-tiered-cache.cpp
@@ -38,7 +38,7 @@ server_tiered_cache::~server_tiered_cache() {
     slot_managers.clear();
 }
 
-bool server_tiered_cache::init_slot(int slot_id, const llama_model& model) {
+bool server_tiered_cache::init_slot(int slot_id, const llama_model& model, struct llama_context * lctx) {
     if (!enabled) {
         return false;
     }
@@ -73,17 +73,20 @@ bool server_tiered_cache::init_slot(int slot_id, const llama_model& model) {
         attention_threshold
     );
 
-    // set bytes-per-token for warm device hipMalloc sizing
-    if (params.kv_warm_device >= 0) {
-        int32_t n_kv_heads = llama_model_n_head_kv(&model);
-        int32_t head_dim   = llama_model_n_embd(&model) / llama_model_n_head(&model);
-        manager.tiered_cache->set_warm_elem_bytes(
-            (size_t)n_kv_heads * head_dim * sizeof(ggml_fp16_t));
-    }
-
-    // Initialize the tiered cache
+    // Initialize the tiered cache (warm slots reserved, buffers come after layer wiring)
     if (!manager.tiered_cache->init()) {
         return false;
+    }
+
+    // Wire per-layer K/V tensor pointers for actual data movement
+    if (lctx) {
+        auto * mem = llama_get_memory(lctx);
+        auto * kv  = dynamic_cast<llama_kv_cache *>(mem);
+        if (kv) {
+            manager.tiered_cache->set_kv_layers_from_cache(kv);
+        } else {
+            SRV_WRN("tiered cache: could not cast memory to llama_kv_cache for slot %d — metadata-only mode\n", slot_id);
+        }
     }
 
     manager.initialized = true;
@@ -104,7 +107,7 @@ server_tiered_cache::slot_tier_manager* server_tiered_cache::get_slot_manager(in
     return &it->second;
 }
 
-bool server_tiered_cache::evict_from_slot(int slot_id, uint32_t n_tokens) {
+bool server_tiered_cache::evict_from_slot(int slot_id, uint32_t n_tokens, uint32_t n_hot_positions) {
     if (!enabled) {
         return false;
     }
@@ -112,6 +115,11 @@ bool server_tiered_cache::evict_from_slot(int slot_id, uint32_t n_tokens) {
     auto* manager = get_slot_manager(slot_id);
     if (!manager || !manager->initialized) {
         return false;
+    }
+
+    // Populate metadata so eviction scoring has candidates to work with
+    if (n_hot_positions > 0) {
+        manager->tiered_cache->track_hot_range(n_hot_positions);
     }
 
     // Evict tokens using the tiered cache

--- a/tools/server/server-tiered-cache.cpp
+++ b/tools/server/server-tiered-cache.cpp
@@ -61,6 +61,7 @@ bool server_tiered_cache::init_slot(int slot_id, const llama_model& model) {
     config.warm_percent = params.kv_tier_warm_pct;
     config.cold_percent = params.kv_tier_cold_pct;
     config.total_ctx = params.n_ctx;
+    config.warm_device = params.kv_warm_device;
 
     // Create tiered cache instance
     manager.tiered_cache = std::make_unique<llama_kv_cache_tiered>(
@@ -71,6 +72,14 @@ bool server_tiered_cache::init_slot(int slot_id, const llama_model& model) {
         compression,
         attention_threshold
     );
+
+    // set bytes-per-token for warm device hipMalloc sizing
+    if (params.kv_warm_device >= 0) {
+        int32_t n_kv_heads = llama_model_n_head_kv(&model);
+        int32_t head_dim   = llama_model_n_embd(&model) / llama_model_n_head(&model);
+        manager.tiered_cache->set_warm_elem_bytes(
+            (size_t)n_kv_heads * head_dim * sizeof(ggml_fp16_t));
+    }
 
     // Initialize the tiered cache
     if (!manager.tiered_cache->init()) {

--- a/tools/server/server-tiered-cache.cpp
+++ b/tools/server/server-tiered-cache.cpp
@@ -28,7 +28,7 @@ server_tiered_cache::server_tiered_cache(const common_params& params)
         // Extract attention threshold
         attention_threshold = params.kv_tier_attention_threshold;
 
-        global_stats.reset();
+        stats_.reset();
     }
 }
 
@@ -120,7 +120,7 @@ bool server_tiered_cache::evict_from_slot(int slot_id, uint32_t n_tokens) {
     if (result) {
         // Update global stats
         std::lock_guard<std::mutex> lock(mutex);
-        global_stats.total_evictions += n_tokens;
+        stats_.total_evictions += n_tokens;
     }
 
     return result;
@@ -145,7 +145,7 @@ bool server_tiered_cache::migrate_in_slot(int slot_id,
     if (result) {
         // Update global stats
         std::lock_guard<std::mutex> lock(mutex);
-        global_stats.total_migrations += positions.size();
+        stats_.total_migrations += positions.size();
     }
 
     return result;
@@ -166,10 +166,10 @@ llama_tier_stats server_tiered_cache::get_slot_stats(int slot_id) {
 
 server_tiered_cache::global_stats server_tiered_cache::get_global_stats() {
     std::lock_guard<std::mutex> lock(mutex);
-    return global_stats;
+    return stats_;
 }
 
 void server_tiered_cache::reset_stats() {
     std::lock_guard<std::mutex> lock(mutex);
-    global_stats.reset();
+    stats_.reset();
 }

--- a/tools/server/server-tiered-cache.cpp
+++ b/tools/server/server-tiered-cache.cpp
@@ -1,0 +1,166 @@
+#include "server-tiered-cache.h"
+
+#include "server-common.h"
+#include "llama.h"
+
+#include <algorithm>
+#include <chrono>
+
+server_tiered_cache::server_tiered_cache(const common_params& params)
+    : params(params) {
+    // Check if tiered cache is enabled
+    enabled = params.kv_tiered_enabled;
+
+    if (enabled) {
+        // Extract SSD path from params
+        ssd_path = params.kv_tier_ssd_path;
+        if (ssd_path.empty()) {
+            // Default SSD path if not specified
+            ssd_path = "./tiered-cache";
+        }
+
+        // Extract eviction policy
+        eviction_policy = llama_eviction_policy(params.kv_tier_eviction_policy);
+
+        // Extract compression type
+        compression = llama_cache_compression(params.kv_tier_compression);
+
+        // Extract attention threshold
+        attention_threshold = params.kv_tier_attention_threshold;
+
+        global_stats.reset();
+    }
+}
+
+server_tiered_cache::~server_tiered_cache() {
+    // Cleanup all slot managers
+    std::lock_guard<std::mutex> lock(mutex);
+    slot_managers.clear();
+}
+
+bool server_tiered_cache::init_slot(int slot_id, const llama_model& model) {
+    if (!enabled) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex);
+
+    // Check if slot already has a manager
+    auto it = slot_managers.find(slot_id);
+    if (it != slot_managers.end()) {
+        // Already initialized
+        return true;
+    }
+
+    // Create new slot manager
+    slot_tier_manager manager;
+
+    // Create tiered cache configuration
+    llama_tier_config config;
+    config.hot_percent = params.kv_tier_hot_pct;
+    config.warm_percent = params.kv_tier_warm_pct;
+    config.cold_percent = params.kv_tier_cold_pct;
+    config.total_ctx = params.n_ctx;
+
+    // Create tiered cache instance
+    manager.tiered_cache = std::make_unique<llama_kv_cache_tiered>(
+        model,
+        config,
+        ssd_path,
+        eviction_policy,
+        compression,
+        attention_threshold
+    );
+
+    // Initialize the tiered cache
+    if (!manager.tiered_cache->init()) {
+        return false;
+    }
+
+    manager.initialized = true;
+    manager.stats.reset();
+    slot_managers.emplace(slot_id, std::move(manager));
+
+    return true;
+}
+
+server_tiered_cache::slot_tier_manager* server_tiered_cache::get_slot_manager(int slot_id) {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    auto it = slot_managers.find(slot_id);
+    if (it == slot_managers.end()) {
+        return nullptr;
+    }
+
+    return &it->second;
+}
+
+bool server_tiered_cache::evict_from_slot(int slot_id, uint32_t n_tokens) {
+    if (!enabled) {
+        return false;
+    }
+
+    auto* manager = get_slot_manager(slot_id);
+    if (!manager || !manager->initialized) {
+        return false;
+    }
+
+    // Evict tokens using the tiered cache
+    bool result = manager->tiered_cache->evict_tokens(n_tokens, TIER_HOT);
+
+    if (result) {
+        // Update global stats
+        std::lock_guard<std::mutex> lock(mutex);
+        global_stats.total_evictions += n_tokens;
+    }
+
+    return result;
+}
+
+bool server_tiered_cache::migrate_in_slot(int slot_id,
+                                           const std::vector<llama_pos>& positions,
+                                           llama_cache_tier from_tier,
+                                           llama_cache_tier to_tier) {
+    if (!enabled) {
+        return false;
+    }
+
+    auto* manager = get_slot_manager(slot_id);
+    if (!manager || !manager->initialized) {
+        return false;
+    }
+
+    // Migrate tokens between tiers
+    bool result = manager->tiered_cache->migrate_tokens(positions, from_tier, to_tier);
+
+    if (result) {
+        // Update global stats
+        std::lock_guard<std::mutex> lock(mutex);
+        global_stats.total_migrations += positions.size();
+    }
+
+    return result;
+}
+
+llama_tier_stats server_tiered_cache::get_slot_stats(int slot_id) {
+    if (!enabled) {
+        return llama_tier_stats{};
+    }
+
+    auto* manager = get_slot_manager(slot_id);
+    if (!manager || !manager->initialized) {
+        return llama_tier_stats{};
+    }
+
+    return manager->tiered_cache->get_stats();
+}
+
+server_tiered_cache::global_stats server_tiered_cache::get_global_stats() {
+    std::lock_guard<std::mutex> lock(mutex);
+    return global_stats;
+}
+
+void server_tiered_cache::reset_stats() {
+    std::lock_guard<std::mutex> lock(mutex);
+    global_stats.reset();
+}

--- a/tools/server/server-tiered-cache.cpp
+++ b/tools/server/server-tiered-cache.cpp
@@ -2,6 +2,10 @@
 
 #include "server-common.h"
 #include "llama.h"
+#include "../../src/llama-memory-hybrid-iswa.h"
+#include "../../src/llama-memory-hybrid.h"
+#include "../../src/llama-kv-cache-iswa.h"
+#include "../../src/llama-kv-cache.h"
 
 #include <algorithm>
 #include <chrono>
@@ -186,12 +190,20 @@ bool server_tiered_cache::init_slot(int slot_id, const llama_model& model, struc
         return false;
     }
 
-    // Wire per-layer K/V tensor pointers for actual data movement
+    // Wire per-layer K/V tensor pointers for actual data movement.
+    // Handle both pure-attention (llama_kv_cache) and hybrid (llama_memory_hybrid_iswa)
+    // models like Qwen3-27B which wrap an iswa KV cache inside a hybrid container.
     if (lctx) {
-        auto * mem = llama_get_memory(lctx);
-        auto * kv  = dynamic_cast<llama_kv_cache *>(mem);
+        auto * mem        = llama_get_memory(lctx);
+        auto * kv         = dynamic_cast<llama_kv_cache *>(mem);
+        auto * hybrid     = dynamic_cast<llama_memory_hybrid *>(mem);
+        auto * hybrid_iswa = dynamic_cast<llama_memory_hybrid_iswa *>(mem);
         if (kv) {
             manager.tiered_cache->set_kv_layers_from_cache(kv);
+        } else if (hybrid && hybrid->get_mem_attn()) {
+            manager.tiered_cache->set_kv_layers_from_cache(hybrid->get_mem_attn());
+        } else if (hybrid_iswa && hybrid_iswa->get_mem_attn()) {
+            manager.tiered_cache->set_kv_layers_from_cache(hybrid_iswa->get_mem_attn()->get_base());
         } else {
             SRV_WRN("tiered cache: could not cast memory to llama_kv_cache for slot %d — metadata-only mode\n", slot_id);
         }

--- a/tools/server/server-tiered-cache.cpp
+++ b/tools/server/server-tiered-cache.cpp
@@ -60,7 +60,7 @@ bool server_tiered_cache::init_slot(int slot_id, const llama_model& model) {
     config.hot_percent = params.kv_tier_hot_pct;
     config.warm_percent = params.kv_tier_warm_pct;
     config.cold_percent = params.kv_tier_cold_pct;
-    config.total_ctx = params.n_ctx;
+    config.total_ctx = params.kv_tier_total_ctx > 0 ? params.kv_tier_total_ctx : params.n_ctx;
     config.warm_device = params.kv_warm_device;
 
     // Create tiered cache instance

--- a/tools/server/server-tiered-cache.h
+++ b/tools/server/server-tiered-cache.h
@@ -27,13 +27,13 @@ struct server_tiered_cache {
     ~server_tiered_cache();
 
     // Initialize tier manager for a slot
-    bool init_slot(int slot_id, const llama_model& model);
+    bool init_slot(int slot_id, const llama_model& model, struct llama_context * lctx = nullptr);
 
     // Get tier manager for a slot
     slot_tier_manager* get_slot_manager(int slot_id);
 
     // Evict tokens from a slot
-    bool evict_from_slot(int slot_id, uint32_t n_tokens);
+    bool evict_from_slot(int slot_id, uint32_t n_tokens, uint32_t n_hot_positions = 0);
 
     // Migrate tokens between tiers for a slot
     bool migrate_in_slot(int slot_id, const std::vector<llama_pos>& positions,

--- a/tools/server/server-tiered-cache.h
+++ b/tools/server/server-tiered-cache.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "llama-kv-cache-tiered.h"
+#include "server-common.h"
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+// Tiered cache manager for server slots
+struct server_tiered_cache {
+    // Per-slot tier manager
+    struct slot_tier_manager {
+        std::unique_ptr<llama_kv_cache_tiered> tiered_cache;
+        llama_tier_stats stats;
+        bool initialized = false;
+
+        void reset() {
+            tiered_cache.reset();
+            stats.reset();
+            initialized = false;
+        }
+    };
+
+    server_tiered_cache(const common_params& params);
+    ~server_tiered_cache();
+
+    // Initialize tier manager for a slot
+    bool init_slot(int slot_id, const llama_model& model);
+
+    // Get tier manager for a slot
+    slot_tier_manager* get_slot_manager(int slot_id);
+
+    // Evict tokens from a slot
+    bool evict_from_slot(int slot_id, uint32_t n_tokens);
+
+    // Migrate tokens between tiers for a slot
+    bool migrate_in_slot(int slot_id, const std::vector<llama_pos>& positions,
+                         llama_cache_tier from_tier, llama_cache_tier to_tier);
+
+    // Get statistics for a slot
+    llama_tier_stats get_slot_stats(int slot_id);
+
+    // Get global statistics
+    struct global_stats {
+        uint64_t total_evictions = 0;
+        uint64_t total_migrations = 0;
+        uint64_t total_cache_hits = 0;
+        uint64_t total_cache_misses = 0;
+        double total_migration_latency_us = 0.0;
+
+        void reset() {
+            total_evictions = 0;
+            total_migrations = 0;
+            total_cache_hits = 0;
+            total_cache_misses = 0;
+            total_migration_latency_us = 0.0;
+        }
+    };
+
+    global_stats get_global_stats();
+
+    // Reset all statistics
+    void reset_stats();
+
+    // Check if tiered cache is enabled
+    bool is_enabled() const { return enabled; }
+
+private:
+    bool enabled = false;
+    std::unordered_map<int, slot_tier_manager> slot_managers;
+    global_stats global_stats;
+    mutable std::mutex mutex;
+
+    common_params params;
+    std::string ssd_path;
+    llama_eviction_policy eviction_policy;
+    llama_cache_compression compression;
+    float attention_threshold;
+};

--- a/tools/server/server-tiered-cache.h
+++ b/tools/server/server-tiered-cache.h
@@ -32,7 +32,7 @@ struct server_tiered_cache {
     // Get tier manager for a slot
     slot_tier_manager* get_slot_manager(int slot_id);
 
-    // Evict tokens from a slot
+    // Evict tokens from a slot (with fingerprint computation if semantic index enabled)
     bool evict_from_slot(int slot_id, uint32_t n_tokens, uint32_t n_hot_positions = 0);
 
     // Migrate tokens between tiers for a slot
@@ -67,6 +67,10 @@ struct server_tiered_cache {
     // Check if tiered cache is enabled
     bool is_enabled() const { return enabled; }
 
+    // Semantic embedding
+    bool sem_enabled() const { return sem_model != nullptr; }
+    std::vector<float> embed(const std::string & text);
+
 private:
     bool enabled = false;
     std::unordered_map<int, slot_tier_manager> slot_managers;
@@ -75,7 +79,23 @@ private:
 
     common_params params;
     std::string ssd_path;
+    std::string fingerprints_path;
     llama_eviction_policy eviction_policy;
     llama_cache_compression compression;
     float attention_threshold;
+
+    // Semantic embedding model for KV fingerprints
+    struct llama_model * sem_model = nullptr;
+    struct llama_context * sem_ctx = nullptr;
+    
+    // Model pointer for detokenization (set during init_slot)
+    const llama_model* detokenize_model = nullptr;
+    
+    // Semantic threshold (private)
+    float semantic_threshold = 0.65f;
+
+public:
+    int semantic_top_k = 5;
+    std::vector<llama_kv_cache_tiered::PrefetchHint>
+    get_prefetch_hints(int slot_id, const std::string& input_text, int top_k = 5);
 };

--- a/tools/server/server-tiered-cache.h
+++ b/tools/server/server-tiered-cache.h
@@ -22,6 +22,7 @@ struct server_tiered_cache {
         }
     };
 
+    server_tiered_cache() : enabled(false) {}
     server_tiered_cache(const common_params& params);
     ~server_tiered_cache();
 
@@ -69,7 +70,7 @@ struct server_tiered_cache {
 private:
     bool enabled = false;
     std::unordered_map<int, slot_tier_manager> slot_managers;
-    global_stats global_stats;
+    global_stats stats_;
     mutable std::mutex mutex;
 
     common_params params;


### PR DESCRIPTION
## AMD ROCm Tiered KV Cache + NVMe Demand Weight Paging

### Overview

This PR implements and stabilizes two major infrastructure features for running large models on AMD ROCm hardware with limited VRAM:

1. **3-tier KV cache** — hot (VRAM), warm (secondary GPU VRAM or RAM), cold (SSD NVMe)
2. **NVMe demand weight paging** — 8-slot VRAM pool with on-demand weight loading for models that exceed VRAM

Both features are WIP infrastructure. Output correctness for weight paging is a known follow-up item.

---

### Tiered KV Cache Fixes

**Warm GPU tier OOM fix**
When `--kv-warm-device N` is set, the pool previously allocated both RAM staging buffers *and* GPU VRAM buffers for all warm slots. On a 262144-slot warm tier this caused ~8GB of wasted RAM and an OOM kill. RAM staging buffers are now skipped when a GPU warm device is configured.

**k_bytes/v_bytes quantization fix**
Per-token KV byte size was computed as `ne[0] * ggml_element_size(tensor)`. For block-quantized types (turbo4, Q4_K, etc.) `ggml_element_size` returns the block size in bytes rather than bytes-per-element, producing a 128× overestimate. Switched to `tensor->nb[1]` (actual row stride), which is correct for all types.

**Hybrid model KV wiring**
`init_slot` cast `llama_get_memory()` to `llama_kv_cache *`. Hybrid-architecture models (Qwen3-27B and similar) return `llama_memory_hybrid` or `llama_memory_hybrid_iswa`, causing silent metadata-only fallback. Added casts for both hybrid types so attention KV layers wire correctly into the tiered cache.

**Tier init logging**
Added startup log lines for warm GPU (`ROCm%d KV warm buffer size = X MiB`) and cold SSD (`cold tier: N slots reserved, path: ...`) to match the existing hot tier output.

---

### Weight Pager Fixes

- **Pool allocation via ggml buffer**: replaced raw `hipMalloc` with `ggml_backend_buft_alloc_buffer`; sets `tensor->buffer = pool.ggml_buf` on page-in so `ggml_cuda_mul_mat` doesn't crash on `src->buffer->buft` dereference
- **Async prefetch disabled by default**: `io_uring` page-index tracking in `complete_prefetch` is broken; disabled until fixed
- **fd dup moved outside prefetch gate**: `page_in` uses `pread` regardless of prefetch state; fds must always be populated
- **O_DIRECT cleared on dup fds**: GGUF tensor offsets are not sector-aligned; O_DIRECT on dup fds caused silent misreads
- **Padding zeroed after hipMemcpy**: zeroes bytes past `page.size` up to `slot_size` so quantized kernel reads past tensor data are safe
- **hipGraph disabled**: `GGML_CUDA_DISABLE_GRAPHS=1` via setenv; removed `static` from `disable_cuda_graphs_due_to_env` in `common.cuh`

---

### Known Issues / Follow-ups

- **Weight pager output correctness**: gallocr allocates paged tensors (buffer=nullptr) in scratchpad, sets `tensor->extra`; callback overrides `data` and `buffer` but not `extra`; GPU kernel reads stale `extra` → coherent but wrong tokens. Fix: pre-seat paged tensors into `pool.ggml_buf` before `ggml_backend_sched_alloc_graph`.
- **Async prefetch**: re-enable after fixing page-index tracking in `complete_prefetch` / `submit_prefetch`
- **Tiered KV eviction under load**: watch for hot→warm→cold pressure as context fills up under concurrent agent workloads

---

### Hardware / Test Config

- AMD Radeon AI PRO R9700 — gfx1201, 32GB VRAM (primary inference + hot KV tier)
- AMD RX 6900XT — 16GB VRAM (warm KV tier via `--kv-warm-device 1`)
- NVMe SSD (cold KV tier, weight paging source)

### Models Tested

| Model | Feature |
|-------|---------|
| Qwen3.6-27B-Q6_K | Tiered KV cache (hot/warm/cold), turbo4 KV quant |
| Qwen3.6-35B-A3B | Tiered KV cache |
| Qwen3.5-REAP-97B | Tiered KV cache |
| MiniMax-M2.7-229B-IQ3_S | NVMe demand weight paging (8-slot VRAM pool, 0.03 t/s) |

> **Note:** As context fills up under concurrent agent workloads, keep an eye on hot→warm→cold eviction pressure. The tiered eviction pipeline is functional but has not been stress-tested at full 512K context utilization.

---

_Co-authored with Claude Sonnet 4.6_
