### PR TITLE
fix: LFM2.5 paged turbo4 on gfx803 (warp-width, sub-128 head_dim, parallel partials)

### DIFF
--- a/ggml/src/ggml-cuda/mt_pagedattn.cu
+++ b/ggml/src/ggml-cuda/mt_pagedattn.cu
@@ -421,7 +421,7 @@ __global__ void mt_scatter_kv_turbo4_0_kernel(
     // ---- Step 6: Pack qs (nibble packed, warp-cooperative) ----
     const int      lane            = j % WARP_SIZE;
     const uint8_t  my_nibble       = idx & 0xF;
-    const uint8_t  partner_nibble  = __shfl_sync(0xffffffffu, my_nibble, lane ^ 1);
+    const uint8_t  partner_nibble  = __shfl_sync(0xffffffffu, my_nibble, lane ^ 1, WARP_SIZE);
     if ((j & 1) == 0) {
         blk->qs[j / 2] = my_nibble | (partner_nibble << 4);
     }

--- a/ggml/src/ggml-cuda/mt_pagedattn.cu
+++ b/ggml/src/ggml-cuda/mt_pagedattn.cu
@@ -1208,7 +1208,7 @@ void ggml_cuda_op_paged_attn_mt(ggml_backend_cuda_context & ctx, ggml_tensor * d
                         num_seqs, (int) k_cur->ne[2], n_kv_heads, stream);
 
                     const int num_chunks    = paged_attn_decode_num_chunks(max_ctx_len);
-                    const int max_q_len     = avg_q_len;  // see comment above
+                    const int max_q_len     = total_q_tokens;  // partials inner stride: must be >= max per-seq q_len. avg_q_len = total/num_seqs floors to 0 with idle parallel slots (1 active + N idle), collapsing every head/seq/chunk partial offset to 0 -> OOB corruption. total_q_tokens (gate-capped <= 8) is a safe upper bound.
                     const size_t partials_n = (size_t) n_heads * (size_t) num_seqs
                                             * (size_t) num_chunks * (size_t) max_q_len
                                             * (size_t) (HS + 2);

--- a/ggml/src/ggml-cuda/mt_pagedattn_aiter.cu
+++ b/ggml/src/ggml-cuda/mt_pagedattn_aiter.cu
@@ -322,7 +322,7 @@ __global__ void mt_scatter_kv_turbo4_aiter_kernel(
     {
         const int      lane            = j % WARP_SIZE;
         const uint8_t  my_nibble       = idx & 0xF;
-        const uint8_t  partner_nibble  = __shfl_sync(0xffffffffu, my_nibble, lane ^ 1);
+        const uint8_t  partner_nibble  = __shfl_sync(0xffffffffu, my_nibble, lane ^ 1, WARP_SIZE);
         if ((j & 1) == 0) {
             blk->qs[j / 2] = my_nibble | (partner_nibble << 4);
         }

--- a/ggml/src/ggml-cuda/mt_pagedattn_decode.cu
+++ b/ggml/src/ggml-cuda/mt_pagedattn_decode.cu
@@ -238,7 +238,7 @@ static __device__ __forceinline__ void decode_coop_stage_turbo4(
                 }
             }
         }
-        norm_f = __shfl_sync(0xFFFFFFFF, norm_f, 0);
+        norm_f = __shfl_sync(0xFFFFFFFF, norm_f, 0, WARP_SIZE);
 
         uint16_t packed = 0;
         if (blk != nullptr) {
@@ -302,7 +302,7 @@ static __device__ __forceinline__ void decode_coop_stage_turbo3(
                 }
             }
         }
-        norm_f = __shfl_sync(0xFFFFFFFF, norm_f, 0);
+        norm_f = __shfl_sync(0xFFFFFFFF, norm_f, 0, WARP_SIZE);
 
         uint8_t qs_byte    = 0;
         uint8_t signs_byte = 0;
@@ -386,7 +386,7 @@ template <typename T>
 __device__ __forceinline__ T decode_warp_reduce_sum(T v) {
     #pragma unroll
     for (int mask = WARP_SIZE / 2; mask > 0; mask >>= 1) {
-        v += __shfl_xor_sync(0xFFFFFFFF, v, mask);
+        v += __shfl_xor_sync(0xFFFFFFFF, v, mask, WARP_SIZE);
     }
     return v;
 }
@@ -395,7 +395,7 @@ template <typename T>
 __device__ __forceinline__ T decode_warp_reduce_max(T v) {
     #pragma unroll
     for (int mask = WARP_SIZE / 2; mask > 0; mask >>= 1) {
-        v = max(v, __shfl_xor_sync(0xFFFFFFFF, v, mask));
+        v = max(v, __shfl_xor_sync(0xFFFFFFFF, v, mask, WARP_SIZE));
     }
     return v;
 }
@@ -938,7 +938,7 @@ __global__ void mt_paged_attention_decode_kernel_wmma(
             float local_max = -INFINITY;
             #pragma unroll
             for (int l = 0; l < scores.ne; ++l) local_max = max(local_max, scores.x[l]);
-            const float row_max = max(local_max, __shfl_xor_sync(0xFFFFFFFF, local_max, 16));
+            const float row_max = max(local_max, __shfl_xor_sync(0xFFFFFFFF, local_max, 16, WARP_SIZE));
 
             const float new_max = max(running_max, row_max);
             float rescale = 1.0f;
@@ -959,7 +959,7 @@ __global__ void mt_paged_attention_decode_kernel_wmma(
                 scores.x[l] = e;
                 local_sum  += e;
             }
-            const float row_sum = local_sum + __shfl_xor_sync(0xFFFFFFFF, local_sum, 16);
+            const float row_sum = local_sum + __shfl_xor_sync(0xFFFFFFFF, local_sum, 16, WARP_SIZE);
             running_sum += row_sum;
             running_max  = new_max;
 

--- a/ggml/src/ggml-cuda/mt_pagedattn_tile.cu
+++ b/ggml/src/ggml-cuda/mt_pagedattn_tile.cu
@@ -230,7 +230,7 @@ static __device__ __forceinline__ void coop_stage_turbo4_tile(
         }
 
         // Broadcast norm from lane 0 to all 32 lanes of this warp.
-        norm_f = __shfl_sync(0xFFFFFFFF, norm_f, 0);
+        norm_f = __shfl_sync(0xFFFFFFFF, norm_f, 0, WARP_SIZE);
 
         // Each lane reads 2 bytes (4 nibbles = 4 elements). qs is uint8_t[64],
         // 2-byte aligned at qs[2*lane_id] for any lane.
@@ -308,7 +308,7 @@ static __device__ __forceinline__ void coop_stage_turbo3_tile(
         }
 
         // Broadcast norm from lane 0 to all 32 lanes of this warp.
-        norm_f = __shfl_sync(0xFFFFFFFF, norm_f, 0);
+        norm_f = __shfl_sync(0xFFFFFFFF, norm_f, 0, WARP_SIZE);
 
         // Each lane reads 1 byte of qs (its 4 elements' low2 bits) and 1
         // byte of signs (covers this lane's 4 elements' high1 bits, plus
@@ -476,7 +476,7 @@ __global__ void mt_paged_attention_tile_kernel(
         for (int l = 0; l < scores.ne; ++l) {
             local_max = max(local_max, scores.x[l]);
         }
-        const float row_max = max(local_max, __shfl_xor_sync(0xFFFFFFFF, local_max, 16));
+        const float row_max = max(local_max, __shfl_xor_sync(0xFFFFFFFF, local_max, 16, WARP_SIZE));
 
         const float new_max = max(running_max, row_max);
 
@@ -502,7 +502,7 @@ __global__ void mt_paged_attention_tile_kernel(
             scores.x[l]   = e;
             local_sum   += e;
         }
-        const float row_sum = local_sum + __shfl_xor_sync(0xFFFFFFFF, local_sum, 16);
+        const float row_sum = local_sum + __shfl_xor_sync(0xFFFFFFFF, local_sum, 16, WARP_SIZE);
         running_sum += row_sum;
         running_max  = new_max;
 
@@ -861,7 +861,7 @@ __global__ void mt_paged_attention_tile_mw_kernel(
             for (int l = 0; l < scores.ne; ++l) {
                 local_max = max(local_max, scores.x[l]);
             }
-            const float row_max = max(local_max, __shfl_xor_sync(0xFFFFFFFF, local_max, 16));
+            const float row_max = max(local_max, __shfl_xor_sync(0xFFFFFFFF, local_max, 16, WARP_SIZE));
 
             const float new_max = max(running_max, row_max);
 
@@ -887,7 +887,7 @@ __global__ void mt_paged_attention_tile_mw_kernel(
                 scores.x[l]   = e;
                 local_sum   += e;
             }
-            const float row_sum = local_sum + __shfl_xor_sync(0xFFFFFFFF, local_sum, 16);
+            const float row_sum = local_sum + __shfl_xor_sync(0xFFFFFFFF, local_sum, 16, WARP_SIZE);
             running_sum += row_sum;
             running_max  = new_max;
 

--- a/ggml/src/ggml-cuda/set-rows.cu
+++ b/ggml/src/ggml-cuda/set-rows.cu
@@ -1068,7 +1068,7 @@ static __global__ void k_set_rows_turbo4(
     const uint8_t my_nibble = idx & 0xF;
     uint8_t qs_byte = 0;
     // Gather nibble from partner thread
-    uint8_t partner_nibble = __shfl_sync(0xffffffff, my_nibble, lane ^ 1);
+    uint8_t partner_nibble = __shfl_sync(0xffffffff, my_nibble, lane ^ 1, WARP_SIZE);
     if (j % 2 == 0) {
         qs_byte = my_nibble | (partner_nibble << 4);
         blk->qs[j / 2] = qs_byte;

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -2659,9 +2659,27 @@ ggml_tensor * llm_graph_context::build_attn(
             }
             return x;
         };
-        ggml_tensor * q_cast = to_f16_cont(q_cur);
-        ggml_tensor * k_cast = to_f16_cont(k_cur);
-        ggml_tensor * v_cast = to_f16_cont(v_cur);
+        // Turbo paged kernel quantizes 128-element blocks (QK_TURBO=128); a
+        // head_dim < 128 (e.g. LFM2.5 head_dim 64) is smaller than one block,
+        // which the kernel rejects. Zero-pad each head to 128 so the proven
+        // HS=128 path runs: the turbo WHT identity makes <WHT(Qp),WHT(Kp)> ==
+        // <Q,K>, and the padded V dims contribute zero and are sliced off the
+        // output below. Mirrors the non-paged turbo path. ggml_pad needs F32,
+        // so pad before the F16 cast.
+        const bool paged_turbo_pad =
+            (layer.k->type == GGML_TYPE_TURBO2_0 ||
+             layer.k->type == GGML_TYPE_TURBO3_0 ||
+             layer.k->type == GGML_TYPE_TURBO4_0);
+        const int64_t paged_orig_head = q_cur->ne[0];
+        const bool    paged_pad_head  = paged_turbo_pad && (paged_orig_head % 128 != 0);
+        auto pad_head_to_128 = [&](ggml_tensor * t) -> ggml_tensor * {
+            const int64_t pad = ((paged_orig_head + 127) / 128) * 128 - paged_orig_head;
+            ggml_tensor * x = (t->type == GGML_TYPE_F32) ? t : ggml_cast(ctx0, t, GGML_TYPE_F32);
+            return ggml_pad(ctx0, x, pad, 0, 0, 0);
+        };
+        ggml_tensor * q_cast = to_f16_cont(paged_pad_head ? pad_head_to_128(q_cur) : q_cur);
+        ggml_tensor * k_cast = to_f16_cont(paged_pad_head ? pad_head_to_128(k_cur) : k_cur);
+        ggml_tensor * v_cast = to_f16_cont(paged_pad_head ? pad_head_to_128(v_cur) : v_cur);
 
         // 2) Forward-expand the source nodes so they're fully computed
         //    before paged_attn reads them.
@@ -2691,6 +2709,14 @@ ggml_tensor * llm_graph_context::build_attn(
         //    projection (often quantized weight × F32 activation) is
         //    typically wired only for F32 activations.
         cur = ggml_cast(ctx0, cur, GGML_TYPE_F32);
+
+        // Slice the turbo head padding back off (see paged_pad_head above):
+        // output mirrors q as [padded_head, n_heads, n_tokens]; keep the first
+        // paged_orig_head dims per head.
+        if (paged_pad_head) {
+            cur = ggml_cont(ctx0, ggml_view_3d(ctx0, cur, paged_orig_head, cur->ne[1], cur->ne[2],
+                                               cur->nb[1], cur->nb[2], 0));
+        }
 
         // 6) Reshape to (head_dim*n_heads, n_tokens) for the wo projection.
         const int64_t n_embd_full = q_cur->ne[0] * q_cur->ne[1];

--- a/src/llama-kv-cache-paged.cpp
+++ b/src/llama-kv-cache-paged.cpp
@@ -120,6 +120,15 @@ llama_kv_cache_paged::llama_kv_cache_paged(
         }
     }
 
+    // Turbo cache quantizes 128-element blocks; pad a sub-128 head_dim up to
+    // 128 so each head is exactly one turbo block (matches the graph-level
+    // padding in llm_graph_context::build_attn for the paged path).
+    const bool paged_cache_is_turbo =
+        (type_k == GGML_TYPE_TURBO2_0 || type_k == GGML_TYPE_TURBO3_0 || type_k == GGML_TYPE_TURBO4_0);
+    if (paged_cache_is_turbo && head_dim % 128 != 0) {
+        head_dim = ((head_dim + 127) / 128) * 128;
+    }
+
     GGML_ASSERT(head_dim > 0 && "head_dim must be > 0");
     GGML_ASSERT(n_kv_heads > 0 && "n_kv_heads must be > 0");
 


### PR DESCRIPTION
## Summary

Makes **LFM2.5-8B-A1B paged turbo4** work correctly on **gfx803 (RX 480)**, and fixes two latent bugs in the `mt_paged_attention` turbo path that affected it. Validated end-to-end on the real service config (512K ctx, `--parallel 4`, turbo4 paged KV + `--kv-tiered 25,25,50` + semantic index) — coherent, correct generation at ~65 tok/s. Resolves **MAD-298**.

Three independent root causes (one commit each):

### 1. `62f4f99ae` — pin turbo4 cooperative warp-collectives to `WARP_SIZE` (gfx803 corruption)
The turbo4 cooperative kernels (`mt_scatter_kv_turbo4_0_kernel`, `decode_coop_stage_turbo4`, the tile decode, and the `set-rows` turbo4 quant) are written for **32-lane warps** (`WARP_SIZE=32`, `DECODE_NUM_WARPS=NUM_THREADS/32`, `lane=tid%32`) but issued bare 3-arg `__shfl_*_sync`, which the HIP shim maps to `width=warpSize`. On gfx803 (GCN) `warpSize=64`, so two logical 32-lane warps share one 64-wide hardware wave:

- **nibble-pack** `__shfl_sync(.., my_nibble, lane^1)` read the partner from the wrong half of the wave for threads 32–63 / 96–127 → ~25% of packed K/V nibbles corrupted.
- **dequant norm broadcast** `__shfl_sync(.., norm_f, 0)` pulled lane-0's norm across the whole 64-wide wave → logical warp 1 used logical warp 0's per-block norm.

Fix: pass `WARP_SIZE` explicitly (4-arg form) on every warp-collective in these kernels. **No-op on CUDA** (warpSize already 32); restores correctness on gfx803.

### 2. `fb556b194` — support sub-128 head_dim for the paged turbo cache (LFM2.5 head_dim 64)
Paged turbo quantizes 128-element blocks (`QK_TURBO=128`); LFM2.5's head_dim 64 is smaller than one block and the dispatch rejected it. Zero-pad q/k/v to 128 in `build_attn` for the paged turbo path (pad before the F16 cast since `ggml_pad` needs F32; slice the output back to head_dim) and size the paged cache to the padded head_dim. Mirrors the non-paged turbo path. Padded Q dims are zero (contribute nothing to QK), padded V output dims are sliced off.

### 3. `93a1e6a11` — size paged-decode partials by `total_q_tokens`, not `avg_q_len` (arch-independent)
`launch_paged_attn_decode` sizes the partials scratch **and strides every head/seq/chunk partial offset** by `max_q_len`, which the dispatch set to `avg_q_len = total_q_tokens / num_seqs`. With `--parallel N` and one active request (1 active seq + N−1 idle slots) this floors to **0** (1/4 = 0):

- `partials_n = n_heads * num_seqs * num_chunks * 0 * (HS+2) = 0` → empty buffer
- `partial_chunk_base = (...) * max_q_len(0) * (HS+2) = 0` for **all** heads/seqs/chunks → every partial write collapses onto offset 0 of a zero-sized buffer → OOB + total collision → token salad.

Only surfaces at `--parallel > 1` (the decode path). Manifested as token-salad on LFM2.5 paged turbo4 at the service's `--parallel 4` (clean at `--parallel 1`); q8_0 only escaped by luck of allocation layout (the OOB is UB). Fix: `max_q_len = total_q_tokens` (a safe upper bound on any single seq's q_len; gate-capped ≤ 8). The decode gate was already fixed to key off `total_q_tokens` for the same flooring reason — this carries that correction through to the buffer sizing it forgot.

## How it was found
The isolated decode harness (`llama-gpu/tests/test_turbo4_decode_full.cu`, `-DHS_TEST=128`) **passed at HS=128 while production was broken** — its test norms varied only slowly across tokens (`0.4 + 0.0007*tok`), masking bug #1's norm contamination. Reproduced only with strongly-varying norms (**rel-L2 0.72 → 0.0003** with the fix). Bisection: q8_0/f16 paged coherent but turbo4 garbage (→ turbo-specific); `--parallel 1` coherent but `--parallel 4` garbage (→ bug #3); `MAD_PAGEDATTN_PROBE=verbose` showed `avg_q_len=0` at parallel 4. The harness norm fill is now a regression guard.

## Testing
- gfx803 isolated harness: scatter + decode (q_len 1/2/4, GQA dims, multi-chunk) all PASS at HS=128/256 after fixes.
- Live service `llama-server-lfm25-8b` (RX 480, full tiered config): coherent + correct, e.g. *"List three primary colors:" → "red, yellow, blue…"*, ~65 tok/s.
- Both builds compile: CUDA `build-army` (sm_61) and ROCm `build-rocm-gfx803`.
- Mneme embedder (`qwen3-06b`) restarted on the new binary — valid 2048-dim embeddings.

## Notes for review / merge
- Commits 1 and 3 are no-ops on CUDA; commit 3 is arch-independent and likely also bears on **MAD-288** (omnicoder paged-turbo4 CUDA corruption under `--parallel>1`) — see that ticket's comment.
- Targets **fork `master`** (not upstream).
